### PR TITLE
Use glvnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ If by any chance it does not work, you need to install nixGL using the same nixp
 NIX_PATH=nixpkgs=https://github.com/nixos/nixpkgs/archive/94d80eb72474bf8243b841058ce45eac2b163943.tar.gz nix build -f ./default.nix nixGLIntel
 ```
 
+# Old nvidia drivers
+
+Users of nvidia legacy driver should use the `backport/noGLVND` branch.
+
 # `nixGLCommon`
 
 `nixGLCommon nixGLXXX` can be used to get `nixGL` executable which fallsback to `nixGLXXX`. It is a shorter name for people with only one OpenGL configuration.

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ let
               url = "http://download.nvidia.com/XFree86/Linux-x86_64/${nvidiaVersion}/NVIDIA-Linux-x86_64-${nvidiaVersion}.run";
               sha256 = nvidiaHash;
             };
-            useGLVND = false;
+            useGLVND = true;
           });
      };
   };
@@ -44,7 +44,7 @@ rec {
       cat > $out/bin/nixGLNvidiaBumblebee << FOO
       #!/usr/bin/env sh
       export LD_LIBRARY_PATH=${nvidia}/lib
-      ${bumblebee}/bin/optirun --ldpath ${nvidia}/lib "\$@"
+      ${bumblebee}/bin/optirun --ldpath ${libglvnd}/lib:${nvidia}/lib "\$@"
       FOO
 
       chmod u+x $out/bin/nixGLNvidiaBumblebee
@@ -61,7 +61,7 @@ rec {
       mkdir -p $out/bin
       cat > $out/bin/nix${api}Nvidia << FOO
       #!/usr/bin/env sh
-      export LD_LIBRARY_PATH=${nvidiaLibsOnly}/lib
+      export LD_LIBRARY_PATH=${libglvnd}/lib:${nvidiaLibsOnly}/lib
       "\$@"
       FOO
 


### PR DESCRIPTION
fix #14

User of legacy drivers (not working with glvnd) are encouraged to use the branch backport/noGLVND