### PR TITLE
Rewrite all rules using pkgs.writeTextFile

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,14 @@ let
   };
 
   nixpkgs = pkgs { overlays = [overlay]; config = {allowUnfree = true;};};
+
+  writeExecutable = { name, text } : nixpkgs.writeTextFile {
+    inherit name text;
+
+    executable = true;
+    destination = "/bin/${name}";
+  };
+
 in
 with nixpkgs;
 rec {
@@ -32,10 +40,8 @@ rec {
       kernel = null;
   };
 
-  nixGLNvidiaBumblebee = writeTextFile {
+  nixGLNvidiaBumblebee = writeExecutable {
     name = "nixGLNvidiaBumblebee";
-    executable = true;
-    destination = "/bin/nixGLNvidiaBumblebee";
     text = ''
       #!/usr/bin/env sh
       export LD_LIBRARY_PATH=${nvidia}/lib:$LD_LIBRARY_PATH
@@ -43,10 +49,8 @@ rec {
       '';
   };
 
-  nixNvidiaWrapper = api: writeTextFile {
+  nixNvidiaWrapper = api: writeExecutable {
     name = "nix${api}Nvidia";
-    executable = true;
-    destination = "/bin/nix${api}Nvidia";
     text = ''
       #!/usr/bin/env sh
       ${lib.optionalString (api == "Vulkan") ''export VK_LAYER_PATH=${nixpkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d''}
@@ -64,10 +68,8 @@ rec {
 
   nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
 
-  nixGLIntel = writeTextFile {
+  nixGLIntel = writeExecutable {
     name = "nixGLIntel";
-    executable = true;
-    destination = "/bin/nixGLIntel";
     text = ''
       #!/usr/bin/env sh
       export LIBGL_DRIVERS_PATH=${mesa_drivers}/lib/dri
@@ -76,10 +78,8 @@ rec {
       '';
   };
 
-  nixVulkanIntel = writeTextFile {
+  nixVulkanIntel = writeExecutable {
     name = "nixVulkanIntel";
-    executable = true;
-    destination = "/bin/nixVulkanIntel";
     text = ''
      #!/usr/bin/env bash
      if [ ! -z "$LD_LIBRARY_PATH" ]; then

--- a/default.nix
+++ b/default.nix
@@ -32,34 +32,22 @@ rec {
       kernel = null;
   };
 
-  nixGLNvidiaBumblebee = runCommand "nixGLNvidiaBumblebee" {
-    buildInputs = [ nvidia bumblebee ];
-
-     meta = with pkgs.stdenv.lib; {
-         description = "A tool to launch OpenGL application on system other than NixOS - Nvidia bumblebee version";
-         homepage = "https://github.com/guibou/nixGL";
-     };
-    } ''
-      mkdir -p $out/bin
-      cat > $out/bin/nixGLNvidiaBumblebee << FOO
+  nixGLNvidiaBumblebee = writeTextFile {
+    name = "nixGLNvidiaBumblebee";
+    executable = true;
+    destination = "/bin/nixGLNvidiaBumblebee";
+    text = ''
       #!/usr/bin/env sh
-      export LD_LIBRARY_PATH=${nvidia}/lib:\$LD_LIBRARY_PATH
-      ${bumblebee}/bin/optirun --ldpath ${libglvnd}/lib:${nvidia}/lib "\$@"
-      FOO
-
-      chmod u+x $out/bin/nixGLNvidiaBumblebee
+      export LD_LIBRARY_PATH=${nvidia}/lib:$LD_LIBRARY_PATH
+      ${bumblebee}/bin/optirun --ldpath ${libglvnd}/lib:${nvidia}/lib "$@"
       '';
+  };
 
-  nixNvidiaWrapper = api: runCommand "nix${api}Nvidia" {
-    buildInputs = [ nvidiaLibsOnly ];
-
-     meta = with pkgs.stdenv.lib; {
-         description = "A tool to launch ${api} application on system other than NixOS - Nvidia version";
-         homepage = "https://github.com/guibou/nixGL";
-     };
-    } ''
-      mkdir -p $out/bin
-      cat > $out/bin/nix${api}Nvidia << 'FOO'
+  nixNvidiaWrapper = api: writeTextFile {
+    name = "nix${api}Nvidia";
+    executable = true;
+    destination = "/bin/nix${api}Nvidia";
+    text = ''
       #!/usr/bin/env sh
       ${lib.optionalString (api == "Vulkan") ''export VK_LAYER_PATH=${nixpkgs.vulkan-validation-layers}/share/vulkan/explicit_layer.d''}
 
@@ -68,43 +56,31 @@ rec {
         nvidiaLibsOnly
       ] ++ lib.optional (api == "Vulkan") nixpkgs.vulkan-validation-layers)
       }''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-      "\$@"
-      FOO
-
-      chmod u+x $out/bin/nix${api}Nvidia
+      "$@"
       '';
+  };
 
   nixGLNvidia = nixNvidiaWrapper "GL";
 
   nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
 
-  nixGLIntel = runCommand "nixGLIntel" {
-    buildInputs = [ mesa_drivers ];
-
-     meta = with pkgs.stdenv.lib; {
-         description = "A tool to launch OpenGL application on system other than NixOS - Intel version";
-         homepage = "https://github.com/guibou/nixGL";
-     };
-    } ''
-      mkdir -p $out/bin
-      cat > $out/bin/nixGLIntel << FOO
+  nixGLIntel = writeTextFile {
+    name = "nixGLIntel";
+    executable = true;
+    destination = "/bin/nixGLIntel";
+    text = ''
       #!/usr/bin/env sh
       export LIBGL_DRIVERS_PATH=${mesa_drivers}/lib/dri
-      export LD_LIBRARY_PATH=${mesa_drivers}/lib:\$LD_LIBRARY_PATH
-      "\$@"
-      FOO
-
-      chmod u+x $out/bin/nixGLIntel
+      export LD_LIBRARY_PATH=${mesa_drivers}/lib:$LD_LIBRARY_PATH
+      "$@"
       '';
+  };
 
-  nixVulkanIntel = runCommand "nixVulkanIntel" {
-     meta = with pkgs.stdenv.lib; {
-         description = "A tool to launch Vulkan application on system other than NixOS - Intel version";
-         homepage = "https://github.com/guibou/nixGL";
-     };
-   } ''
-     mkdir -p "$out/bin"
-     cat > "$out/bin/nixVulkanIntel" << EOF
+  nixVulkanIntel = writeTextFile {
+    name = "nixVulkanIntel";
+    executable = true;
+    destination = "/bin/nixVulkanIntel";
+    text = ''
      #!/usr/bin/env bash
      if [ ! -z "$LD_LIBRARY_PATH" ]; then
        echo "Warning, nixVulkanIntel overwriting existing LD_LIBRARY_PATH" 1>&2
@@ -117,12 +93,10 @@ rec {
        xorg.libxshmfence
        wayland
        gcc.cc
-     ]}:\$LD_LIBRARY_PATH
-     exec "\$@"
-     EOF
-     chmod u+x "$out/bin/nixVulkanIntel"
-     ${shellcheck}/bin/shellcheck "$out/bin/nixVulkanIntel"
-    '';
+     ]}:$LD_LIBRARY_PATH
+     exec "$@"
+     '';
+  };
 
   nixGLCommon = nixGL:
     runCommand "nixGLCommon" {

--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,10 @@ let
 
     executable = true;
     destination = "/bin/${name}";
+
+    checkPhase = ''
+       ${nixpkgs.shellcheck}/bin/shellcheck "$out/bin/${name}"
+    '';
   };
 
 in
@@ -82,7 +86,7 @@ rec {
     name = "nixVulkanIntel";
     text = ''
      #!/usr/bin/env bash
-     if [ ! -z "$LD_LIBRARY_PATH" ]; then
+     if [ -n "$LD_LIBRARY_PATH" ]; then
        echo "Warning, nixVulkanIntel overwriting existing LD_LIBRARY_PATH" 1>&2
      fi
      export LD_LIBRARY_PATH=${lib.makeLibraryPath [


### PR DESCRIPTION
- It is more compact and easier to read
- Escaping is correctly done

This closes #21 and #22

This is a diff of all the binaries:

```
diff -r results_before/nixGLNvidia/bin/nixGLNvidia results_after/nixGLNvidia/bin/nixGLNvidia
5c5
< "\$@"
---
> "$@"
diff -r results_before/nixVulkanIntel/bin/nixVulkanIntel results_after/nixVulkanIntel/bin/nixVulkanIntel
2c2
< if [ ! -z "" ]; then
---
> if [ ! -z "$LD_LIBRARY_PATH" ]; then
diff -r results_before/nixVulkanNvidia/bin/nixVulkanNvidia results_after/nixVulkanNvidia/bin/nixVulkanNvidia
5c5
< "\$@"
---
> "$@"
```

So we can indeed see that the `\$@` problem of #22 is fixed and that the `LD_LIBRARY_PATH` is correctly passed, fixing #21.