### PR TITLE
Test.hs: make sure to build the impure NVIDIA version derivation locally

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -32,6 +32,8 @@ let
         # To avoid sharing the build result over time or between machine,
         # Add an impure parameter to force the rebuild on each access.
         time = builtins.currentTime;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
       }
       "cp /proc/driver/nvidia/version $out || touch $out";
 


### PR DESCRIPTION
The NVIDIA driver version check was built on one of my remote builders, causing it to fail. This PR forces it to build locally. Newer nixpkgs versions have `runCommandLocal` as a shortcut for this, but this is not available in 19.09.

Also, all the tests except the plain NVIDIA tests (which I would expect to fail) passed on my Optimus laptop with an NVIDIA GTX960M. It sounds like you already have similar hardware, but I am willing to test things in the future.

The only problem I ran into was that bbswitch unloads the NVIDIA driver when not in use, causing the version check to fail unless I ran something that used the GPU in the background.