### PR TITLE
Fix evaluation with allowAliases = false

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -14,7 +14,7 @@
   # bit the size of nixGL closure.
   enable32bits ? true,
   writeTextFile, shellcheck, pcre, runCommand, linuxPackages, fetchurl, lib,
-  runtimeShell, bumblebee, libglvnd, vulkan-validation-layers, mesa_drivers,
+  runtimeShell, bumblebee, libglvnd, vulkan-validation-layers, mesa,
   pkgsi686Linux,zlib, libdrm, xorg, wayland, gcc
 }:
 
@@ -131,11 +131,11 @@ in
     name = "nixGLIntel";
     # add the 32 bits drivers if needed
     text = let
-      drivers = [mesa_drivers] ++ lib.optional enable32bits pkgsi686Linux.mesa_drivers;
+      drivers = [mesa.drivers] ++ lib.optional enable32bits pkgsi686Linux.mesa.drivers;
       glxindirect = runCommand "mesa_glxindirect" {}
         (
           ''mkdir -p $out/lib
-            ln -s ${mesa_drivers}/lib/libGLX_mesa.so.0 $out/lib/libGLX_indirect.so.0
+            ln -s ${mesa.drivers}/lib/libGLX_mesa.so.0 $out/lib/libGLX_indirect.so.0
           ''
           );
     in ''
@@ -155,10 +155,10 @@ in
       icd = runCommand "mesa_icd" {}
         (
           # 64 bits icd
-          ''ls ${mesa_drivers}/share/vulkan/icd.d/*.json > f
+          ''ls ${mesa.drivers}/share/vulkan/icd.d/*.json > f
           ''
           #  32 bits ones
-          + lib.optionalString enable32bits ''ls ${pkgsi686Linux.mesa_drivers}/share/vulkan/icd.d/*.json >> f
+          + lib.optionalString enable32bits ''ls ${pkgsi686Linux.mesa.drivers}/share/vulkan/icd.d/*.json >> f
           ''
           # concat everything as a one line string with ":" as seperator
           + ''cat f | xargs | sed "s/ /:/g" > $out''


### PR DESCRIPTION
mesa_drivers is a legacy alias for mesa.drivers.
