### PR TITLE
fix: nvidia version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ To get started,
 
 ```bash
 $ nix-channel --add https://github.com/guibou/nixGL/archive/master.tar.gz nixgl && nix-channel --update
-$ nix-env -iA nixgl.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
+$ nix-env -iA nixgl.auto.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
 ```
 
 Many wrappers are available, depending on your hardware and the graphical API you want to use (i.e. Vulkan or OpenGL). You may want to install a few of them, for example if you want to support OpenGL and Vulkan on a laptop with an hybrid configuration.
 
 OpenGL wrappers:
 
-- `nixGLDefault`: Tries to auto-detect and install Nvidia, if not, fallback to mesa. Recommended. Invoke with `nixGL program`.
-- `nixGLNvidia`: Proprietary Nvidia driver.
+- `auto.nixGLDefault`: Tries to auto-detect and install Nvidia, if not, fallback to mesa. Recommended. Invoke with `nixGL program`.
+- `auto.nixGLNvidia`: Proprietary Nvidia driver (auto detection of version)
+- `auto.nixGLNvidiaBumblebee`: Proprietary Nvidia driver on hybrid hardware (auto detection).
 - `nixGLIntel`: Mesa OpenGL implementation (intel, amd, nouveau, ...).
-- `nixGLNvidiaBumblebee`: Proprietary Nvidia driver on hybrid hardware.
 
 Vulkan wrappers:
 
-- `nixVulkanNvidia`: Proprietary Nvidia driver.
-- `nixVulkanIntel`: Mesa Vulkan implementation.
+- `auto.nixVulkanNvidia`: Proprietary Nvidia driver (auto detection).
+- `auto.nixVulkanIntel`: Mesa Vulkan implementation (auto detection).
 
 The Vulkan wrapper also sets `VK_LAYER_PATH` the validation layers in the nix store.
 
@@ -76,7 +76,7 @@ $ nixGLNvidiaBumblebee program args
 For Vulkan programs:
 
 ```bash
-$ nixVulkanNividia program args
+$ nixVulkanNvidia program args
 $ nixVulkanIntel program args
 ```
 
@@ -132,6 +132,9 @@ You can run the Nvidia installer using an explicit version string instead of the
 nix-build -A nixGLNvidia --argstr nvidiaVersion 440.82
 ```
 
+(or `nixGLNvidiaBumblebee`, `nixVulkanNividia`)
+
+
 The version of your driver can be found using `glxinfo` from your system default package manager, or `nvidia-settings`.
 
 ## On nixOS
@@ -150,7 +153,7 @@ Users of Nvidia legacy driver should use the `backport/noGLVND` branch. This bra
 
 # `nixGLCommon`
 
-`nixGLCommon nixGLXXX` can be used to get `nixGL` executable which fallsback to `nixGLXXX`. It is a shorter name for people with only one OpenGL configuration.
+`nixGLCommon nixGLXXX` can be used to get `nixGL` executable which fallback to `nixGLXXX`. It is a shorter name for people with only one OpenGL configuration.
 
 For example:
 

--- a/all.nix
+++ b/all.nix
@@ -6,11 +6,11 @@ let
     nvidiaHash = "edd415acf2f75a659e0f3b4f27c1fab770cf21614e84a18152d94f0d004a758e";
   });
 
-  versionFile = pkgs.recurseIntoAttrs (pkgs.callPackage ./nixGL.nix {
+  versionFile = (pkgs.callPackage ./nixGL.nix {
     nvidiaVersionFile = pkgs.writeText "nvidia-version-440.82" ''
       NVRM version: NVIDIA UNIX x86_64 Kernel Module  440.82  Wed Apr  1 20:04:33 UTC 2020
       GCC version:  gcc version 9.3.0 (Arch Linux 9.3.0-1)
     '';
   });
 in
-(with pure; [nixGLIntel nixVulkanNvidia nixGLNvidia nixVulkanIntel]) ++ (with versionFile; [nixGLNvidia nixGLDefault nixVulkanNvidia])
+(with pure; [nixGLIntel nixVulkanNvidia nixGLNvidia nixVulkanIntel]) ++ (with versionFile.auto; [nixGLNvidia nixGLDefault nixVulkanNvidia])

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -1,201 +1,230 @@
-{ ## Nvidia informations.
-  # Version of the system kernel module. Let it to null to enable auto-detection.
-  nvidiaVersion ? null,
-  # Hash of the Nvidia driver .run file. null is fine, but fixing a value here
-  # will be more reproducible and more efficient.
-  nvidiaHash ? null,
-  # Alternatively, you can pass a path that points to a nvidia version file
-  # and let nixGL extract the version from it. That file must be a copy of
-  # /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
-  # https://github.com/NixOS/nix/issues/3539 ).
-  nvidiaVersionFile ? null,
-  # Enable 32 bits driver
-  # This is one by default, you can switch it to off if you want to reduce a
-  # bit the size of nixGL closure.
-  enable32bits ? true,
-  writeTextFile, shellcheck, pcre, runCommand, linuxPackages, fetchurl, lib,
-  runtimeShell, bumblebee, libglvnd, vulkan-validation-layers, mesa,
-  pkgsi686Linux,zlib, libdrm, xorg, wayland, gcc
-}:
+{ # # Nvidia informations.
+# Version of the system kernel module. Let it to null to enable auto-detection.
+nvidiaVersion ? null,
+# Hash of the Nvidia driver .run file. null is fine, but fixing a value here
+# will be more reproducible and more efficient.
+nvidiaHash ? null,
+# Alternatively, you can pass a path that points to a nvidia version file
+# and let nixGL extract the version from it. That file must be a copy of
+# /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
+# https://github.com/NixOS/nix/issues/3539 ).
+nvidiaVersionFile ? null,
+# Enable 32 bits driver
+# This is one by default, you can switch it to off if you want to reduce a
+# bit the size of nixGL closure.
+enable32bits ? true, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
+, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
+, mesa, pkgsi686Linux, zlib, libdrm, xorg, wayland, gcc }:
 
 let
-  _nvidiaVersionFile =
-    if nvidiaVersionFile != null then
-      nvidiaVersionFile
-    else
+  writeExecutable = { name, text }:
+    writeTextFile {
+      inherit name text;
+
+      executable = true;
+      destination = "/bin/${name}";
+
+      checkPhase = ''
+        ${shellcheck}/bin/shellcheck "$out/bin/${name}"
+
+        # Check that all the files listed in the output binary exists
+        for i in $(${pcre}/bin/pcregrep  -o0 '/nix/store/.*?/[^ ":]+' $out/bin/${name})
+        do
+          ls $i > /dev/null || (echo "File $i, referenced in $out/bin/${name} does not exists."; exit -1)
+        done
+      '';
+    };
+  top = rec {
+    /*
+    It contains the builder for different nvidia configuration, parametrized by
+    the version of the driver and sha256 sum of the driver installer file.
+    */
+    nvidiaPackages = { version, sha256 ? null }: rec {
+      nvidiaDrivers = (linuxPackages.nvidia_x11.override { }).overrideAttrs
+        (oldAttrs: rec {
+          pname = "nvidia";
+          inherit version;
+          src = let
+            url =
+              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}.run";
+          in if sha256 != null then
+            fetchurl { inherit url sha256; }
+          else
+            builtins.fetchurl url;
+          useGLVND = true;
+        });
+
+      nvidiaLibsOnly = nvidiaDrivers.override {
+        libsOnly = true;
+        kernel = null;
+      };
+
+      nixGLNvidiaBumblebee = writeExecutable {
+        name = "nixGLNvidiaBumblebee-${version}";
+        text = ''
+          #!${runtimeShell}
+          export LD_LIBRARY_PATH=${
+            lib.makeLibraryPath [ nvidiaDrivers ]
+          }:$LD_LIBRARY_PATH
+          ${
+            bumblebee.override {
+              nvidia_x11 = nvidiaDrivers;
+              nvidia_x11_i686 = nvidiaDrivers.lib32;
+            }
+          }/bin/optirun --ldpath ${
+            lib.makeLibraryPath ([ libglvnd nvidiaDrivers ]
+              ++ lib.optionals enable32bits [
+                nvidiaDrivers.lib32
+                pkgsi686Linux.libglvnd
+              ])
+          } "$@"
+        '';
+      };
+
+      # TODO: 32bit version? Not tested.
+      nixNvidiaWrapper = api:
+        writeExecutable {
+          name = "nix${api}Nvidia-${version}";
+          text = ''
+            #!${runtimeShell}
+            ${lib.optionalString (api == "Vulkan")
+            "export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d"}
+
+              ${
+                lib.optionalString (api == "Vulkan")
+                "export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.json${
+                  lib.optionalString enable32bits
+                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.json"
+                }:$VK_ICD_FILENAMES"
+              }
+              export LD_LIBRARY_PATH=${
+                lib.makeLibraryPath ([ libglvnd nvidiaLibsOnly ]
+                  ++ lib.optional (api == "Vulkan") vulkan-validation-layers
+                  ++ lib.optionals enable32bits [
+                    nvidiaLibsOnly.lib32
+                    pkgsi686Linux.libglvnd
+                  ])
+              }:''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+              "$@"
+          '';
+        };
+
+      # TODO: 32bit version? Not tested.
+      nixGLNvidia = nixNvidiaWrapper "GL";
+
+      # TODO: 32bit version? Not tested.
+      nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
+    };
+
+    nixGLIntel = writeExecutable {
+      name = "nixGLIntel";
+      # add the 32 bits drivers if needed
+      text = let
+        drivers = [ mesa.drivers ]
+          ++ lib.optional enable32bits pkgsi686Linux.mesa.drivers;
+        glxindirect = runCommand "mesa_glxindirect" { } (''
+          mkdir -p $out/lib
+                      ln -s ${mesa.drivers}/lib/libGLX_mesa.so.0 $out/lib/libGLX_indirect.so.0
+                    '');
+      in ''
+        #!${runtimeShell}
+        export LIBGL_DRIVERS_PATH=${
+          lib.makeSearchPathOutput "lib" "lib/dri" drivers
+        }
+        export LD_LIBRARY_PATH=${
+          lib.makeLibraryPath drivers
+        }:${glxindirect}/lib:$LD_LIBRARY_PATH
+        "$@"
+      '';
+    };
+
+    nixVulkanIntel = writeExecutable {
+      name = "nixVulkanIntel";
+      text = let
+        # generate a file with the listing of all the icd files
+        icd = runCommand "mesa_icd" { } (
+          # 64 bits icd
+          ''
+            ls ${mesa.drivers}/share/vulkan/icd.d/*.json > f
+                      ''
+          #  32 bits ones
+          + lib.optionalString enable32bits ''
+            ls ${pkgsi686Linux.mesa.drivers}/share/vulkan/icd.d/*.json >> f
+                      ''
+          # concat everything as a one line string with ":" as seperator
+          + ''cat f | xargs | sed "s/ /:/g" > $out'');
+      in ''
+        #!${runtimeShell}
+        if [ -n "$LD_LIBRARY_PATH" ]; then
+          echo "Warning, nixVulkanIntel overwriting existing LD_LIBRARY_PATH" 1>&2
+        fi
+        export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d
+        ICDS=$(cat ${icd})
+        export VK_ICD_FILENAMES=$ICDS:$VK_ICD_FILENAMES
+        export LD_LIBRARY_PATH=${
+          lib.makeLibraryPath [
+            zlib
+            libdrm
+            xorg.libX11
+            xorg.libxcb
+            xorg.libxshmfence
+            wayland
+            gcc.cc
+          ]
+        }:$LD_LIBRARY_PATH
+        exec "$@"
+      '';
+    };
+
+    nixGLCommon = nixGL:
+      runCommand "nixGLCommon" { } ''
+        mkdir -p "$out/bin"
+        # star because nixGLNvidia... have version prefixed name
+        cp ${nixGL}/bin/* "$out/bin/nixGL";
+      '';
+
+    auto = let
+      _nvidiaVersionFile = if nvidiaVersionFile != null then
+        nvidiaVersionFile
+      else
       # HACK: Get the version from /proc. It turns out that /proc is mounted
       # inside of the build sandbox and varies from machine to machine.
       #
       # builtins.readFile is not able to read /proc files. See
       # https://github.com/NixOS/nix/issues/3539.
-      runCommand "impure-nvidia-version-file" {
-        # To avoid sharing the build result over time or between machine,
-        # Add an impure parameter to force the rebuild on each access.
-        time = builtins.currentTime;
-        preferLocalBuild = true;
-        allowSubstitutes = false;
-      }
-      "cp /proc/driver/nvidia/version $out || touch $out";
+        runCommand "impure-nvidia-version-file" {
+          # To avoid sharing the build result over time or between machine,
+          # Add an impure parameter to force the rebuild on each access.
+          time = builtins.currentTime;
+          preferLocalBuild = true;
+          allowSubstitutes = false;
+        } "cp /proc/driver/nvidia/version $out || touch $out";
 
-  # The nvidia version. Either fixed by the `nvidiaVersion` argument, or
-  # auto-detected. Auto-detection is impure.
-  _nvidiaVersion =
-    if nvidiaVersion != null then
-      nvidiaVersion
-    else
-      # Get if from the nvidiaVersionFile
-      let
-        data = builtins.readFile _nvidiaVersionFile;
-        versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
-      in
-      if versionMatch != null then
-        builtins.head versionMatch
+      # The nvidia version. Either fixed by the `nvidiaVersion` argument, or
+      # auto-detected. Auto-detection is impure.
+      nvidiaVersionAuto = if nvidiaVersion != null then
+        nvidiaVersion
       else
-        null;
+      # Get if from the nvidiaVersionFile
+        let
+          data = builtins.readFile _nvidiaVersionFile;
+          versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
+        in if versionMatch != null then builtins.head versionMatch else null;
 
-  addNvidiaVersion = drv: drv.overrideAttrs(oldAttrs: {
-    name = oldAttrs.name + "-${_nvidiaVersion}";
-  });
-
-  writeExecutable = { name, text } : writeTextFile {
-    inherit name text;
-
-    executable = true;
-    destination = "/bin/${name}";
-
-
-    checkPhase = ''
-     ${shellcheck}/bin/shellcheck "$out/bin/${name}"
-
-     # Check that all the files listed in the output binary exists
-     for i in $(${pcre}/bin/pcregrep  -o0 '/nix/store/.*?/[^ ":]+' $out/bin/${name})
-     do
-       ls $i > /dev/null || (echo "File $i, referenced in $out/bin/${name} does not exists."; exit -1)
-     done
-    '';
+      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
+    in rec {
+      # The output derivation contains nixGL which point either to
+      # nixGLNvidia or nixGLIntel using an heuristic.
+      nixGLDefault = if nvidiaVersionAuto != null then
+        nixGLCommon autoNvidia.nixGLNvidia
+      else
+        nixGLCommon nixGLIntel;
+    } // autoNvidia;
   };
-in
-  rec {
-    nvidia = (linuxPackages.nvidia_x11.override {
-    }).overrideAttrs(oldAttrs: rec {
-      name = "nvidia-${_nvidiaVersion}";
-      src = let url = "https://download.nvidia.com/XFree86/Linux-x86_64/${_nvidiaVersion}/NVIDIA-Linux-x86_64-${_nvidiaVersion}.run";
-      in if nvidiaHash != null
-      then fetchurl {
-        inherit url;
-        sha256 = nvidiaHash;
-      } else
-      builtins.fetchurl url;
-      useGLVND = true;
-    });
-
-    nvidiaLibsOnly = nvidia.override {
-      libsOnly = true;
-      kernel = null;
-    };
-
-  nixGLNvidiaBumblebee = addNvidiaVersion (writeExecutable {
-    name = "nixGLNvidiaBumblebee";
-    text = ''
-      #!${runtimeShell}
-      export LD_LIBRARY_PATH=${lib.makeLibraryPath [nvidia]}:$LD_LIBRARY_PATH
-      ${bumblebee.override {nvidia_x11 = nvidia; nvidia_x11_i686 = nvidia.lib32;}}/bin/optirun --ldpath ${lib.makeLibraryPath ([libglvnd nvidia] ++ lib.optionals enable32bits [nvidia.lib32 pkgsi686Linux.libglvnd])} "$@"
-    '';
-  });
-
-  # TODO: 32bit version? Not tested.
-  nixNvidiaWrapper = api: addNvidiaVersion (writeExecutable {
-    name = "nix${api}Nvidia";
-    text = ''
-      #!${runtimeShell}
-      ${lib.optionalString (api == "Vulkan") ''export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d''}
-
-        ${lib.optionalString (api == "Vulkan") ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.json${lib.optionalString enable32bits ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.json"}:$VK_ICD_FILENAMES''}
-        export LD_LIBRARY_PATH=${lib.makeLibraryPath ([
-          libglvnd
-          nvidiaLibsOnly
-        ] ++ lib.optional (api == "Vulkan") vulkan-validation-layers
-        ++ lib.optionals enable32bits [nvidiaLibsOnly.lib32 pkgsi686Linux.libglvnd])
-      }:''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-        "$@"
-      '';
-    });
-
-  # TODO: 32bit version? Not tested.
-  nixGLNvidia = nixNvidiaWrapper "GL";
-
-  # TODO: 32bit version? Not tested.
-  nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
-
-  nixGLIntel = writeExecutable {
-    name = "nixGLIntel";
-    # add the 32 bits drivers if needed
-    text = let
-      drivers = [mesa.drivers] ++ lib.optional enable32bits pkgsi686Linux.mesa.drivers;
-      glxindirect = runCommand "mesa_glxindirect" {}
-        (
-          ''mkdir -p $out/lib
-            ln -s ${mesa.drivers}/lib/libGLX_mesa.so.0 $out/lib/libGLX_indirect.so.0
-          ''
-          );
-    in ''
-      #!${runtimeShell}
-      export LIBGL_DRIVERS_PATH=${lib.makeSearchPathOutput "lib" "lib/dri" drivers}
-      export LD_LIBRARY_PATH=${
-        lib.makeLibraryPath drivers
-      }:${glxindirect}/lib:$LD_LIBRARY_PATH
-      "$@"
-    '';
-  };
-
-  nixVulkanIntel = writeExecutable {
-    name = "nixVulkanIntel";
-    text = let
-      # generate a file with the listing of all the icd files
-      icd = runCommand "mesa_icd" {}
-        (
-          # 64 bits icd
-          ''ls ${mesa.drivers}/share/vulkan/icd.d/*.json > f
-          ''
-          #  32 bits ones
-          + lib.optionalString enable32bits ''ls ${pkgsi686Linux.mesa.drivers}/share/vulkan/icd.d/*.json >> f
-          ''
-          # concat everything as a one line string with ":" as seperator
-          + ''cat f | xargs | sed "s/ /:/g" > $out''
-          );
-      in ''
-     #!${runtimeShell}
-     if [ -n "$LD_LIBRARY_PATH" ]; then
-       echo "Warning, nixVulkanIntel overwriting existing LD_LIBRARY_PATH" 1>&2
-     fi
-     export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d
-     ICDS=$(cat ${icd})
-     export VK_ICD_FILENAMES=$ICDS:$VK_ICD_FILENAMES
-     export LD_LIBRARY_PATH=${lib.makeLibraryPath [
-       zlib
-       libdrm
-       xorg.libX11
-       xorg.libxcb
-       xorg.libxshmfence
-       wayland
-       gcc.cc
-     ]}:$LD_LIBRARY_PATH
-     exec "$@"
-    '';
-  };
-
-  nixGLCommon = nixGL: runCommand "nixGLCommon" {} ''
-    mkdir -p "$out/bin"
-    # star because nixGLNvidia... have version prefixed name
-    cp ${nixGL}/bin/* "$out/bin/nixGL";
-  '';
-
-  # The output derivation contains nixGL which point either to
-  # nixGLNvidia or nixGLIntel using an heuristic.
-  nixGLDefault =
-    if _nvidiaVersion != null then
-      nixGLCommon nixGLNvidia
-    else
-      nixGLCommon nixGLIntel
-    ;
-}
+in top // (if nvidiaVersion != null then
+  top.nvidiaPackages {
+    version = nvidiaVersion;
+    sha256 = nvidiaHash;
+  }
+else
+  { })


### PR DESCRIPTION
Closes #72. There was two problems related to the way `_nvidiaVersion` was
detected.

- `nixGLCommon` was using `_nvidiaVersion` in nix, which was failing
  when using `nix-env` for search because, for yet unknown reason the
  IFD `readFile` call was not working in this context.
- all `nvidia` packages had their name set to contain the auto-detected
  version, which leads to error on a system where the version cannot be
  auto-detected. This is fixed, now the version is either `unknown` if
  not explicitly fixed, or known.