### PR TITLE
nixGLIntel: Add libGL to LD_LIBRARY_PATH

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -14,7 +14,7 @@ nvidiaVersionFile ? null,
 # bit the size of nixGL closure.
 enable32bits ? true
 , writeTextFile, shellcheck, pcre, runCommand, linuxPackages
-, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
+, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers, libGL
 , mesa, libvdpau-va-gl, intel-media-driver, vaapiIntel, pkgsi686Linux, driversi686Linux
 , zlib, libdrm, xorg, wayland, gcc }:
 
@@ -137,7 +137,7 @@ let
         #!${runtimeShell}
         export LIBGL_DRIVERS_PATH=${lib.makeSearchPathOutput "lib" "lib/dri" mesa-drivers}
         export LIBVA_DRIVERS_PATH=${lib.makeSearchPathOutput "out" "lib/dri" intel-driver}
-        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau}:${glxindirect}/lib:$LD_LIBRARY_PATH
+        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau}:${glxindirect}/lib:${lib.makeLibraryPath [libGL]}:$LD_LIBRARY_PATH
         "$@"
       '';
     };

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -14,7 +14,7 @@ nvidiaVersionFile ? null,
 # bit the size of nixGL closure.
 enable32bits ? true
 , writeTextFile, shellcheck, pcre, runCommand, linuxPackages
-, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers, libGL
+, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
 , mesa, libvdpau-va-gl, intel-media-driver, vaapiIntel, pkgsi686Linux, driversi686Linux
 , zlib, libdrm, xorg, wayland, gcc }:
 
@@ -137,7 +137,7 @@ let
         #!${runtimeShell}
         export LIBGL_DRIVERS_PATH=${lib.makeSearchPathOutput "lib" "lib/dri" mesa-drivers}
         export LIBVA_DRIVERS_PATH=${lib.makeSearchPathOutput "out" "lib/dri" intel-driver}
-        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau}:${glxindirect}/lib:${lib.makeLibraryPath [libGL]}:$LD_LIBRARY_PATH
+        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau}:${glxindirect}/lib:${lib.makeLibraryPath [libglvnd]}:$LD_LIBRARY_PATH
         "$@"
       '';
     };


### PR DESCRIPTION
We have an Rust application using `imgui` with `glfw` where `nixGLIntel`
doesn't work: the application throws some issue about not being able to
create a window. However, on this same machine, `nixGLIntel <glxgears
from nixpkgs>` worked.

After trying to use `apitrace` and then `strace`, I noticed that it's
trying to open `libGL.so` and then `libGL.so.1` when that eventually
fails. This however does not exist in the nixpkgs mesa package:
https://github.com/NixOS/nixpkgs/issues/40001. There seems to have been
some fixes regarding to the mesa change back in
https://github.com/guibou/nixGL/issues/10 but presumably it didn't
address this particular problem.

I am not sure if this is the correct fix for the issue: let me know if
something else is supposed to be done, I'm not too privy as to how all
this graphics stuff works. It seems to work for my use-case however.

I guess `nixVulkanIntel` doesn't need such treatment as it's only about
OpenGL?