### PR TITLE
feat: add flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,36 @@ Vulkan wrappers:
 
 The Vulkan wrapper also sets `VK_LAYER_PATH` the validation layers in the nix store.
 
+## flakes
+
+Add nixGL as a flake input:
+
+
+```Nix
+{
+  inputs = {
+    nixgl.url = "github:guibou/nixGL";
+  };
+  outputs = { nixgl, ... }: { };
+}
+```
+
+Then, use the flake's `overlay` attr:
+
+```Nix
+{
+  outputs = { nixgl, nixpkgs, ... }:
+  let
+    pkgs = import nixpkgs {
+      system = "x86_64-linux";
+      overlays = [ nixgl.overlay ];
+    };
+  in
+  # You can now reference pkgs.nixgl.nixGLIntel, etc.
+  { }
+}
+```
+
 ## Installation from source
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643087856,
+        "narHash": "sha256-EreC7gP/T566PDRZjqNoTvByTyvABEpJpWFtyNUDS0Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8bd55a6a5ab05942af769c2aa2494044bff7f625",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,40 +1,6 @@
 {
   "nodes": {
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1643087856,
-        "narHash": "sha256-EreC7gP/T566PDRZjqNoTvByTyvABEpJpWFtyNUDS0Y=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8bd55a6a5ab05942af769c2aa2494044bff7f625",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -1,24 +1,8 @@
 {
   description = "A wrapper tool for nix OpenGL applications";
-  inputs = {
-    flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self }: {
+    overlay = _: prev: {
+      nixgl = import ./default.nix { pkgs = prev; };
+    };
   };
-  outputs = { self, flake-utils, nixpkgs }:
-    {
-      overlay = _: prev: {
-        nixgl = import ./default.nix { pkgs = prev; };
-      };
-    }
-    // flake-utils.lib.eachDefaultSystem (system:
-    let
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-        overlays = [ self.overlay ];
-      };
-    in
-    {
-      packages.nixGLIntel = pkgs.nixgl.nixGLIntel;
-      packages.nixVulkanIntel = pkgs.nixgl.nixVulkanIntel;
-    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "A wrapper tool for nix OpenGL applications";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, flake-utils, nixpkgs }:
+    {
+      overlay = _: prev: {
+        nixgl = import ./default.nix { pkgs = prev; };
+      };
+    }
+    // flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+        overlays = [ self.overlay ];
+      };
+    in
+    {
+      packages.nixGLIntel = pkgs.nixgl.nixGLIntel;
+      packages.nixVulkanIntel = pkgs.nixgl.nixVulkanIntel;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,8 @@
 {
   description = "A wrapper tool for nix OpenGL applications";
   outputs = { self }: {
-    overlay = _: prev: {
-      nixgl = import ./default.nix { pkgs = prev; };
+    overlay = final: _: {
+      nixgl = import ./default.nix { pkgs = final; };
     };
   };
 }


### PR DESCRIPTION
This adds a simple flake to the repo with the `nixGLIntel` and `nixVulkanIntel`
packages, since they are the only one that evaluate purely.

It also exposes an overlay which just adds the `nixgl` attr to `pkgs`.
