### PR TITLE
Silence false error on non-nvidia systems

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -202,7 +202,7 @@ let
           time = builtins.currentTime;
           preferLocalBuild = true;
           allowSubstitutes = false;
-        } "cp /proc/driver/nvidia/version $out || touch $out";
+        } "cp /proc/driver/nvidia/version $out 2> /dev/null || touch $out";
 
       # The nvidia version. Either fixed by the `nvidiaVersion` argument, or
       # auto-detected. Auto-detection is impure.


### PR DESCRIPTION
This was causing the auto-detection mechanism to show maybe scary but actually innocuous errors on the terminal. This fixes that.