### PR TITLE
Inclusive nix flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,13 +17,19 @@
   # able to access the nvidia drivers.
   pkgs ? import <nixpkgs> {
     config = { allowUnfree = true; };
-  }
+  },
+  # Enable all Intel specific extensions which only works on x86_64
+  enableIntelX86Extensions ? true
 }:
-pkgs.callPackage ./nixGL.nix {
+pkgs.callPackage ./nixGL.nix ({
   inherit
     nvidiaVersion
     nvidiaVersionFile
     nvidiaHash
     enable32bits
     ;
-}
+  } // (if enableIntelX86Extensions then {}
+  else {
+    intel-media-driver = null;
+    vaapiIntel = null;
+  }))

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1660551188,
+        "narHash": "sha256-a1LARMMYQ8DPx1BgoI/UN4bXe12hhZkCNqdxNi6uS0g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "441dc5d512153039f19ef198e662e4f3dbb9fd65",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,29 +1,41 @@
 {
   description = "A wrapper tool for nix OpenGL applications";
 
-  outputs = { self, nixpkgs }:
-    let
-      pkgs =
-        import ./default.nix { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
-    in rec {
-      overlays.default = final: _: {
-        nixgl = import ./default.nix { pkgs = final; };
-      };
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
 
-      packages.x86_64-linux = {
-        # makes it easy to use "nix run nixGL --impure -- program"
-        default = pkgs.auto.nixGLDefault;
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        isIntelX86Platform = if system == "x86_64-linux" then true else false;
+        pkgs = import ./default.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+          enable32bits = isIntelX86Platform;
+          enableIntelX86Extensions = isIntelX86Platform;
+        };
+      in rec {
+        overlays.default = final: _: {
+          nixgl = import ./default.nix {
+            pkgs = final;
+            enable32bits = isIntelX86Platform;
+            enableIntelX86Extensions = isIntelX86Platform;
+          };
+        };
 
-        nixGLDefault = pkgs.auto.nixGLDefault;
-        nixGLNvidia = pkgs.auto.nixGLNvidia;
-        nixGLNvidiaBumblebee = pkgs.auto.nixGLNvidiaBumblebee;
-        nixGLIntel = pkgs.nixGLIntel;
-        nixVulkanNvidia = pkgs.auto.nixVulkanNvidia;
-        nixVulkanIntel = pkgs.nixVulkanIntel;
-      };
+        packages = {
+          # makes it easy to use "nix run nixGL --impure -- program"
+          default = pkgs.auto.nixGLDefault;
 
-      # deprecated attributes for retro compatibility
-      defaultPackage.x86_64-linux = packages.x86_64-linux.default;
-      overlay = overlays.default;
-    };
+          nixGLDefault = pkgs.auto.nixGLDefault;
+          nixGLNvidia = pkgs.auto.nixGLNvidia;
+          nixGLNvidiaBumblebee = pkgs.auto.nixGLNvidiaBumblebee;
+          nixGLIntel = pkgs.nixGLIntel;
+          nixVulkanNvidia = pkgs.auto.nixVulkanNvidia;
+          nixVulkanIntel = pkgs.nixVulkanIntel;
+        };
+
+        # deprecated attributes for retro compatibility
+        defaultPackage = packages;
+        overlay = overlays.default;
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,27 +1,29 @@
 {
   description = "A wrapper tool for nix OpenGL applications";
 
-  outputs = { self, nixpkgs }: let 
-    pkgs = import ./default.nix { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
-  in rec {
-    overlays.default = final: _: {
-      nixgl = import ./default.nix { pkgs = final; };
+  outputs = { self, nixpkgs }:
+    let
+      pkgs =
+        import ./default.nix { pkgs = nixpkgs.legacyPackages.x86_64-linux; };
+    in rec {
+      overlays.default = final: _: {
+        nixgl = import ./default.nix { pkgs = final; };
+      };
+
+      packages.x86_64-linux = {
+        # makes it easy to use "nix run nixGL --impure -- program"
+        default = pkgs.auto.nixGLDefault;
+
+        nixGLDefault = pkgs.auto.nixGLDefault;
+        nixGLNvidia = pkgs.auto.nixGLNvidia;
+        nixGLNvidiaBumblebee = pkgs.auto.nixGLNvidiaBumblebee;
+        nixGLIntel = pkgs.nixGLIntel;
+        nixVulkanNvidia = pkgs.auto.nixVulkanNvidia;
+        nixVulkanIntel = pkgs.nixVulkanIntel;
+      };
+
+      # deprecated attributes for retro compatibility
+      defaultPackage.x86_64-linux = packages.x86_64-linux.default;
+      overlay = overlays.default;
     };
-
-    packages.x86_64-linux = {
-      # makes it easy to use "nix run nixGL --impure -- program"
-      default = pkgs.auto.nixGLDefault;
-
-      nixGLDefault = pkgs.auto.nixGLDefault;
-      nixGLNvidia = pkgs.auto.nixGLNvidia;
-      nixGLNvidiaBumblebee = pkgs.auto.nixGLNvidiaBumblebee;
-      nixGLIntel = pkgs.nixGLIntel;
-      nixVulkanNvidia = pkgs.auto.nixVulkanNvidia;
-      nixVulkanIntel = pkgs.nixVulkanIntel;
-    };
-
-    # deprecated attributes for retro compatibility
-    defaultPackage.x86_64-linux = packages.x86_64-linux.default;
-    overlay = overlays.default;
-  };
 }


### PR DESCRIPTION
feat: flake support for more than x86-64


This should close https://github.com/guibou/nixGL/issues/109.

I had to:

- setup flake for all supported architectures
- special case 32bits packages and some intel specific packages which
  does not have meaning outside of the x86_64 world.