### PR TITLE
fix: overlay definitions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs";
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+    (flake-utils.lib.eachDefaultSystem (system:
       let
         isIntelX86Platform = if system == "x86_64-linux" then true else false;
         pkgs = import ./default.nix {
@@ -14,13 +14,6 @@
           enableIntelX86Extensions = isIntelX86Platform;
         };
       in rec {
-        overlays.default = final: _: {
-          nixgl = import ./default.nix {
-            pkgs = final;
-            enable32bits = isIntelX86Platform;
-            enableIntelX86Extensions = isIntelX86Platform;
-          };
-        };
 
         packages = {
           # makes it easy to use "nix run nixGL --impure -- program"
@@ -36,6 +29,19 @@
 
         # deprecated attributes for retro compatibility
         defaultPackage = packages;
+      })) // rec {
+        # deprecated attributes for retro compatibility
         overlay = overlays.default;
-      });
+        overlays.default = final: _:
+          let
+            isIntelX86Platform =
+              if final.system == "x86_64-linux" then true else false;
+          in {
+            nixgl = import ./default.nix {
+              pkgs = final;
+              enable32bits = isIntelX86Platform;
+              enableIntelX86Extensions = isIntelX86Platform;
+            };
+          };
+      };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     (flake-utils.lib.eachDefaultSystem (system:
       let
-        isIntelX86Platform = if system == "x86_64-linux" then true else false;
+        isIntelX86Platform = system == "x86_64-linux";
         pkgs = import ./default.nix {
           pkgs = nixpkgs.legacyPackages.${system};
           enable32bits = isIntelX86Platform;
@@ -33,9 +33,7 @@
         # deprecated attributes for retro compatibility
         overlay = overlays.default;
         overlays.default = final: _:
-          let
-            isIntelX86Platform =
-              if final.system == "x86_64-linux" then true else false;
+          let isIntelX86Platform = final.system == "x86_64-linux";
           in {
             nixgl = import ./default.nix {
               pkgs = final;


### PR DESCRIPTION
Move `overlays` outside of the `eachDefaultSystem` loop, because
overlays are function, not attrset containing different systems.

Fix #111.