### PR TITLE
feat: more nixGL variants

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -131,7 +131,7 @@ let
                 lib.optionalString (api == "Vulkan")
                 ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
                   lib.optionalString enable32bits
-                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.json"
+                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
                 }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
               }
               export LD_LIBRARY_PATH=${

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -129,7 +129,7 @@ let
 
               ${
                 lib.optionalString (api == "Vulkan")
-                ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.json${
+                ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
                   lib.optionalString enable32bits
                   ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.json"
                 }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -15,7 +15,7 @@ nvidiaVersionFile ? null,
 enable32bits ? true
 , writeTextFile, shellcheck, pcre, runCommand, linuxPackages
 , fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
-, mesa, libvdpau-va-gl, intel-media-driver, vaapiIntel, vaapiVdpau, pkgsi686Linux, driversi686Linux
+, mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
 , zlib, libdrm, xorg, wayland, gcc }:
 
 let
@@ -156,12 +156,9 @@ let
 
     nixGLMesa = writeNixGL "nixGLMesa" [  ];
 
-    nixGLMesaVdpau = writeNixGL "nixGLMesaVdpau" [ vaapiVdpau ];
-
     nixGLIntel = writeNixGL "nixGLIntel"
-      ([ intel-media-driver vaapiIntel ]
-       # Note: intel-media-driver is disabled for i686 until https://github.com/NixOS/nixpkgs/issues/140471 is fixed
-       ++ lib.optionals enable32bits [ /* pkgsi686Linux.intel-media-driver */ driversi686Linux.vaapiIntel ]);
+      ([ intel-media-driver ]
+       ++ lib.optionals enable32bits [ pkgsi686Linux.intel-media-driver ]);
 
     nixVulkanMesa = writeExecutable {
       name = "nixVulkanIntel";


### PR DESCRIPTION
amd gpus need vaapi drivers from mesa, intel from the intel drivers, some other cards might need to fallback to vaapiVdpau.

Add the mesa driver by default and give some more granular driver options nixGLMesa (for pure mesa), niGLVdpau which uses vaapiVdpau, nixGLIntel for intel drivers.

Additionally I renamed nixVulkanIntel to nixVulkanMesa (to better reflect what it is) and added nixVulkanIntel = nixVulkanMesa for compatibility.

Using this fixes (nix installed mpv, moonlight, and I think also firefox) with vaapi on my amd system and therefore probably https://github.com/guibou/nixGL/issues/115.

The driver auto selection is not chaged as nixGLIntel should now work for amd and intel systems, while nixGLMesa only works on systems that have all drivers in mesa.