### PR TITLE
feat: set OCL_ICD_VENDORS so that OpenCL loads

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -134,6 +134,7 @@ let
                   ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
                 }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
               }
+              export OCL_ICD_VENDORS=${nvidiaLibsOnly}/etc/OpenCL/vendors
               export LD_LIBRARY_PATH=${
                 lib.makeLibraryPath ([ libglvnd nvidiaLibsOnly ]
                   ++ lib.optional (api == "Vulkan") vulkan-validation-layers


### PR DESCRIPTION
In order for `clinfo` to detect the OpenCL platform, I need to set the `OCL_ICD_VENDORS` env var in this manner