### PR TITLE
fix: only generate a version file if nvidiaVersion isn't set

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -208,7 +208,9 @@ let
       '';
 
     auto = let
-      _nvidiaVersionFile = if nvidiaVersionFile != null then
+      _nvidiaVersionFile = if nvidiaVersionFile != null || nvidiaVersion != null then
+        # In the case nvidiaVersion is not null, nvidiaVersionFile is not used
+        # so we can set _nvidiaVersionFile == nvidiaVersionFile == null
         nvidiaVersionFile
       else
       # HACK: Get the version from /proc. It turns out that /proc is mounted
@@ -235,7 +237,7 @@ let
           versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
         in if versionMatch != null then builtins.head versionMatch else null;
 
-      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
+      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; sha256 = nvidiaHash;};
     in rec {
       # The output derivation contains nixGL which point either to
       # nixGLNvidia or nixGLIntel using an heuristic.


### PR DESCRIPTION
When using nixGL in a flake, it would be convenient to use the `auto.nixGLDefault` attribute to generate a `nixGL` wrapper (previously I was generating `nixGLnvidia-<version>`. 

`auto.nixGLDefault` can't be used in a flake because there are two impure operations, first is generating the version file, and second is fetching the sha256 for the runfile. 

This PR prevents those two operations from occuring if the user provides `nvidiaVersion` and `nvidiaHash` arguments to nixGL

Hunk 1: prevents the version file generation if `nvidiaVersion` is passed, see the comment in the code for why this works
Hunk 2: simply passes `nvidiaHash` to `nvidiaPackages`, in the case `nvidiaHash` is null, this should fetch the hash as before.
 