### PR TITLE
fix: handle unset `buildInputs`

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -81,7 +81,7 @@ let
           else
             builtins.fetchurl url;
           useGLVND = true;
-          nativeBuildInputs = oldAttrs.buildInputs ++ [zstd];
+          nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [zstd];
         });
 
       nvidiaLibsOnly = nvidiaDrivers.override {


### PR DESCRIPTION
I just set up a Void Linux machine, using `home-manager` and the `nixGL` overlay on a somewhat recent version of `nixpkgs-unstable`. Trying to install the package `nixgl.auto.nixGLDefault` on this system failed here: https://github.com/nix-community/nixGL/blob/d709a8abcde5b01db76ca794280745a43c8662be/nixGL.nix#L84