### PR TITLE
fix: forward nvidiaHash for nixgl.auto derivation too

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -249,10 +249,5 @@ let
         nixGLCommon nixGLIntel;
     } // autoNvidia;
   };
-in top // (if nvidiaVersion != null then
-  top.nvidiaPackages {
-    version = nvidiaVersion;
-    sha256 = nvidiaHash;
-  }
-else
-  { })
+in top // lib.optionalAttrs (nvidiaVersion != null)
+(builtins.removeAttrs top.auto [ "nixGLDefault" ])

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -236,7 +236,10 @@ let
           versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
         in if versionMatch != null then builtins.head versionMatch else null;
 
-      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
+      autoNvidia = nvidiaPackages {
+        version = nvidiaVersionAuto;
+        sha256 = nvidiaHash;
+      };
     in rec {
       # The output derivation contains nixGL which point either to
       # nixGLNvidia or nixGLIntel using an heuristic.


### PR DESCRIPTION
This allows separating the *use* of nixgl.auto.nixGLDefault from the
location where we pass nvidiaHash to provide a pure instantiation.

Without this usage of `nixgl.auto.XXX` is always impure.

Also reuse `nixgl.auto` in `top` when nVidia is forced instead of
duplicating its definition, because that leaves the possibility for
bugs when these duplicates aren't in sync.