### PR TITLE
fix: build on non-x86 (aarch64) platforms

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,8 +31,7 @@ pkgs.callPackage ./nixGL.nix ({
   } // (if enableIntelX86Extensions then {}
   else {
     intel-media-driver = null;
-  }) // (if enable32bits then {}
-  else {
+  }) // (lib.optionalAttrs (!enable32bits) {
     pkgsi686Linux = null;
     driversi686Linux = null;
   })

--- a/default.nix
+++ b/default.nix
@@ -12,7 +12,7 @@
   # Enable 32 bits driver
   # This is on by default, you can switch it to off if you want to reduce a
   # bit the size of nixGL closure.
-  enable32bits ? true,
+  enable32bits ? pkgs.stdenv.hostPlatform.isx86,
   # Make sure to enable config.allowUnfree to the instance of nixpkgs to be
   # able to access the nvidia drivers.
   pkgs ? import <nixpkgs> {
@@ -31,4 +31,9 @@ pkgs.callPackage ./nixGL.nix ({
   } // (if enableIntelX86Extensions then {}
   else {
     intel-media-driver = null;
-  }))
+  }) // (if enable32bits then {}
+  else {
+    pkgsi686Linux = null;
+    driversi686Linux = null;
+  })
+)

--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ pkgs.callPackage ./nixGL.nix ({
   } // (if enableIntelX86Extensions then {}
   else {
     intel-media-driver = null;
-  }) // (lib.optionalAttrs (!enable32bits) {
+  }) // (pkgs.lib.optionalAttrs (!enable32bits) {
     pkgsi686Linux = null;
     driversi686Linux = null;
   })

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -242,8 +242,10 @@ let
       # nixGLNvidia or nixGLIntel using an heuristic.
       nixGLDefault = if nvidiaVersionAuto != null then
         nixGLCommon autoNvidia.nixGLNvidia
+      else if stdenv.hostPlatform.isx86 then
+        nixGLCommon nixGLIntel
       else
-        nixGLCommon nixGLIntel;
+        nixGLCommon nixGLMesa;
     } // autoNvidia;
   };
 in top // (if nvidiaVersion != null then


### PR DESCRIPTION
This pull request fixes a few issues that I have been encountering when using NixGL in nix-shell and as a runtime dependency on a Raspberry Pi 5 (aarch64):

- the `enable32bits` parameter was always on by default, causing trouble down the line. It has now been changed to be on by default *when on an x86 system* and off otherwise.
- `pkgsi686Linux` and `driversi686Linux` were always being pulled as package dependencies regardless of whether `enable32bits` was on or not, making the build fail since they are not available on ARM. They now only get pulled in if `enable32bits` is on.
- `auto.nixGLDefault` would always fall back to `nixGLIntel`, pulling in and attempting to build the Intel display drivers without much of a need for them. Fallback has been changed to use `nixGLIntel` on an x86 system and to `nixGLMesa` elsewhere.

I hope to not have broken anything else - unfortunately I have not had the occasion to test this on an x86 PC.