### PR TITLE
Fix Error: Kernel module version format change (closes #186)

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -233,8 +233,8 @@ let
       # Get if from the nvidiaVersionFile
         let
           data = builtins.readFile _nvidiaVersionFile;
-          versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
-        in if versionMatch != null then builtins.head versionMatch else null;
+          versionMatch = builtins.match ".*Module( for [^ ]+)?  ([0-9.]+)  .*" data;
+        in if versionMatch != null then builtins.tail versionMatch else null;
 
       autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
     in rec {

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -234,7 +234,7 @@ let
         let
           data = builtins.readFile _nvidiaVersionFile;
           versionMatch = builtins.match ".*Module( for [^ ]+)?  ([0-9.]+)  .*" data;
-        in if versionMatch != null then builtins.tail versionMatch else null;
+        in if versionMatch != null then lib.lists.last versionMatch else null;
 
       autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
     in rec {


### PR DESCRIPTION
Adapts the version matching logic to accommodate version strings in newer open source NVIDIA kernel driver modules as described in #186.