### PR TITLE
fix: set `GBM_BACKENDS_PATH`

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -51,6 +51,7 @@ let
         '');
       in ''
         #!${runtimeShell}
+        export GBM_BACKENDS_PATH=${lib.makeSearchPathOutput "lib" "lib/gbm" mesa-drivers}
         export LIBGL_DRIVERS_PATH=${lib.makeSearchPathOutput "lib" "lib/dri" mesa-drivers}
         export LIBVA_DRIVERS_PATH=${lib.makeSearchPathOutput "out" "lib/dri" (mesa-drivers ++ vadrivers)}
         ${''export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json${


### PR DESCRIPTION
This is necessary to fix `nixGLIntel` for at least `cage` on SteamOS with nixos-unstable using the overlay.