### PR TITLE
fix: update nvidia driver download url

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -75,7 +75,7 @@ let
           inherit version;
           src = let
             url =
-              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}.run";
+              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}.run";
           in if sha256 != null then
             fetchurl { inherit url sha256; }
           else


### PR DESCRIPTION
This PR will fix the download url of the Nvidia driver. as "https://download.nvidia.com" responds with 404.