### PR TITLE
Add ability to get driver from NVIDIA's official RHEL repository, to avoid version issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Then, use the flake's `overlay` attr:
 }
 ```
 
-### Install from RHEL repository (Rocky, CentOS, Fedora, etc.)
+### Install from RHEL repository (RHEL, Rocky, AlmaLinux, CentOS Stream)
 
 On RHEL-based distros the NVIDIA driver is installed from NVIDIA's official driver repositories, and the exact installed version is rarely (if ever) published as a `.run` file on the driver download site. Trying to fetch it from there typically fails with a 404. To guarantee a version match, nixGL can instead extract the driver libraries from the official `.rpm` packages in NVIDIA's RHEL CUDA repository.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ libGL error: failed to load driver: swrast
 NixGL provides a set of wrappers able to launch GL or Vulkan applications:
 
 ```bash
-$ nixGL program
-$ nixVulkan program
+nixGL program
+nixVulkan program
 ```
 
 # Installation
@@ -32,8 +32,8 @@ $ nixVulkan program
 To get started,
 
 ```bash
-$ nix-channel --add https://github.com/nix-community/nixGL/archive/main.tar.gz nixgl && nix-channel --update
-$ nix-env -iA nixgl.auto.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
+nix-channel --add https://github.com/nix-community/nixGL/archive/main.tar.gz nixgl && nix-channel --update
+nix-env -iA nixgl.auto.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
 ```
 
 Many wrappers are available, depending on your hardware and the graphical API you want to use (i.e. Vulkan or OpenGL). You may want to install a few of them, for example if you want to support OpenGL and Vulkan on a laptop with an hybrid configuration.
@@ -84,7 +84,6 @@ nix profile install github:guibou/nixGL --impure
 
 This will result in a lighter download and execution time. Also, this evaluation is pure.
 
-
 #### Error about experimental features
 
 You can directly use:
@@ -98,6 +97,7 @@ Or set the appropriate conf in `~/.config/nix/nix.conf` / `/etc/nix/nix.conf` / 
 #### Error with GLIBC version
 
 if you get errors with messages similar to
+
 ```
 /nix/store/g02b1lpbddhymmcjb923kf0l7s9nww58-glibc-2.33-123/lib/libc.so.6: version `GLIBC_2.34' not found (required by /nix/store/hrl51nkr7dszlwcs29wmyxq0jsqlaszn-libglvnd-1.4.0/lib/libGLX.so.0)
 ```
@@ -107,7 +107,6 @@ It means that there's a mismatch between the versions of `nixpkgs` used by `nixG
 ### Use an overlay
 
 Add nixGL as a flake input:
-
 
 ```Nix
 {
@@ -134,12 +133,39 @@ Then, use the flake's `overlay` attr:
 }
 ```
 
+### Install from RHEL repository (Rocky, CentOS, Fedora, etc.)
+
+On RHEL the NVIDIA driver is typically installed via the official NVIDIA driver repositories. Trying to install the driver from the download site will commonly fail with a 404 error. This is due to the fact that NVIDIA is not providing consistent versions of their drivers across distribution channels, so you might have a driver version installed on your system that is not available on the download site. Therefore on RHEL distros the driver should be retrieved from the RHEL repository, and extracted from an official `.rpm`.
+
+To get the driver from the RHEL `.rpm` instead of the driver download site, simply set `driverSource` to `rhel`. Also ensure that `enable32bits` is changed from its default to `false`, as a 32bit version of the driver is not included. Here's an example flake using
+the nixGL overlay with `home-manager`:
+
+```nix
+{
+  home.packages = with pkgs; [
+    (nixgl.override {
+      driverSource = "rhel";
+      enable32bits = false;
+    }).auto.nixGLDefault
+    (config.lib.nixGL.wrap ghostty)
+  ];
+
+  nixGL = {
+   packages = pkgs.nixgl.override {
+    driverSource = "rhel";
+    enable32bits = false;
+   };
+   defaultWrapper = "nvidia";
+  };
+};
+```
+
 ## Installation from source
 
 ```bash
-$ git clone https://github.com/nix-community/nixGL
-$ cd nixGL
-$ nix-env -f ./ -iA <your desired wrapper name>
+git clone https://github.com/nix-community/nixGL
+cd nixGL
+nix-env -f ./ -iA <your desired wrapper name>
 ```
 
 # Usage
@@ -149,17 +175,17 @@ Just launch the program you want prefixed by the right wrapper.
 For example, for OpenGL programs:
 
 ```bash
-$ nixGL program args                 # For the `nixGLDefault` wrapper, recommended.
-$ nixGLNvidia program args
-$ nixGLIntel program args
-$ nixGLNvidiaBumblebee program args
+nixGL program args                 # For the `nixGLDefault` wrapper, recommended.
+nixGLNvidia program args
+nixGLIntel program args
+nixGLNvidiaBumblebee program args
 ```
 
 For Vulkan programs:
 
 ```bash
-$ nixVulkanNvidia program args
-$ nixVulkanIntel program args
+nixVulkanNvidia program args
+nixVulkanIntel program args
 ```
 
 # OpenGL - Hybrid Intel + Nvidia laptop
@@ -176,7 +202,7 @@ OpenGL version string: 4.6.0 NVIDIA 390.25
 If the program you'd like to run is already installed by nix in your current environment, you can simply run it with the wrapper, for example:
 
 ```bash
-$ nixGLIntel blender
+nixGLIntel blender
 ```
 
 # Vulkan - Intel GPU
@@ -215,7 +241,6 @@ nix-build -A auto.nixGLNvidia --argstr nvidiaVersion 440.82
 ```
 
 (or `nixGLNvidiaBumblebee`, `nixVulkanNividia`)
-
 
 The version of your driver can be found using `glxinfo` from your system default package manager, or `nvidia-settings`.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ the nixGL overlay with `home-manager`:
    packages = pkgs.nixgl.override {
     driverSource = "rhel";
     enable32bits = false;
+    rhelMajorVersion = 10;
    };
    defaultWrapper = "nvidia";
   };

--- a/README.md
+++ b/README.md
@@ -161,6 +161,17 @@ the nixGL overlay with `home-manager`:
 };
 ```
 
+Set `rhelMajorVersion` to match your distribution (e.g. `9` or `10`); it selects the `rhelN`/`elN` repository path.
+
+NVIDIA occasionally reorganizes how the driver is split across RPMs. nixGL pulls
+the GL/EGL/GLX libraries from `nvidia-driver-libs` and the NVML library
+(`libnvidia-ml.so`, needed by tools like `btop`) from a second package. Up to the
+595 branch that package is the standalone `libnvidia-ml`; starting with the 610
+branch NVIDIA dropped it and moved NVML into `nvidia-driver-common`, so nixGL
+selects the right one automatically based on your detected driver branch. If a
+future branch reshuffles packaging again, the `mlPackage` selection in
+`nixGL.nix` is where to adjust it.
+
 ## Installation from source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ libGL error: failed to load driver: swrast
 NixGL provides a set of wrappers able to launch GL or Vulkan applications:
 
 ```bash
-nixGL program
-nixVulkan program
+$ nixGL program
+$ nixVulkan program
 ```
 
 # Installation
@@ -32,8 +32,8 @@ nixVulkan program
 To get started,
 
 ```bash
-nix-channel --add https://github.com/nix-community/nixGL/archive/main.tar.gz nixgl && nix-channel --update
-nix-env -iA nixgl.auto.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
+$ nix-channel --add https://github.com/nix-community/nixGL/archive/main.tar.gz nixgl && nix-channel --update
+$ nix-env -iA nixgl.auto.nixGLDefault   # or replace `nixGLDefault` with your desired wrapper
 ```
 
 Many wrappers are available, depending on your hardware and the graphical API you want to use (i.e. Vulkan or OpenGL). You may want to install a few of them, for example if you want to support OpenGL and Vulkan on a laptop with an hybrid configuration.
@@ -84,6 +84,7 @@ nix profile install github:guibou/nixGL --impure
 
 This will result in a lighter download and execution time. Also, this evaluation is pure.
 
+
 #### Error about experimental features
 
 You can directly use:
@@ -97,7 +98,6 @@ Or set the appropriate conf in `~/.config/nix/nix.conf` / `/etc/nix/nix.conf` / 
 #### Error with GLIBC version
 
 if you get errors with messages similar to
-
 ```
 /nix/store/g02b1lpbddhymmcjb923kf0l7s9nww58-glibc-2.33-123/lib/libc.so.6: version `GLIBC_2.34' not found (required by /nix/store/hrl51nkr7dszlwcs29wmyxq0jsqlaszn-libglvnd-1.4.0/lib/libGLX.so.0)
 ```
@@ -107,6 +107,7 @@ It means that there's a mismatch between the versions of `nixpkgs` used by `nixG
 ### Use an overlay
 
 Add nixGL as a flake input:
+
 
 ```Nix
 {
@@ -135,10 +136,9 @@ Then, use the flake's `overlay` attr:
 
 ### Install from RHEL repository (Rocky, CentOS, Fedora, etc.)
 
-On RHEL the NVIDIA driver is typically installed via the official NVIDIA driver repositories. Trying to install the driver from the download site will commonly fail with a 404 error. This is due to the fact that NVIDIA is not providing consistent versions of their drivers across distribution channels, so you might have a driver version installed on your system that is not available on the download site. Therefore on RHEL distros the driver should be retrieved from the RHEL repository, and extracted from an official `.rpm`.
+On RHEL-based distros the NVIDIA driver is installed from NVIDIA's official driver repositories, and the exact installed version is rarely (if ever) published as a `.run` file on the driver download site. Trying to fetch it from there typically fails with a 404. To guarantee a version match, nixGL can instead extract the driver libraries from the official `.rpm` packages in NVIDIA's RHEL CUDA repository.
 
-To get the driver from the RHEL `.rpm` instead of the driver download site, simply set `driverSource` to `rhel`. Also ensure that `enable32bits` is changed from its default to `false`, as a 32bit version of the driver is not included. Here's an example flake using
-the nixGL overlay with `home-manager`:
+To do so, set `driverSource` to `rhel`. Also set `enable32bits` to `false`, as no 32-bit driver is included, and set `rhelMajorVersion` to match your distribution (e.g. `9` or `10`); it selects the `rhelN`/`elN` repository path. Here's an example flake using the nixGL overlay with `home-manager`:
 
 ```nix
 {
@@ -146,6 +146,7 @@ the nixGL overlay with `home-manager`:
     (nixgl.override {
       driverSource = "rhel";
       enable32bits = false;
+      rhelMajorVersion = 10;
     }).auto.nixGLDefault
     (config.lib.nixGL.wrap ghostty)
   ];
@@ -161,23 +162,14 @@ the nixGL overlay with `home-manager`:
 };
 ```
 
-Set `rhelMajorVersion` to match your distribution (e.g. `9` or `10`); it selects the `rhelN`/`elN` repository path.
-
-NVIDIA occasionally reorganizes how the driver is split across RPMs. nixGL pulls
-the GL/EGL/GLX libraries from `nvidia-driver-libs` and the NVML library
-(`libnvidia-ml.so`, needed by tools like `btop`) from a second package. Up to the
-595 branch that package is the standalone `libnvidia-ml`; starting with the 610
-branch NVIDIA dropped it and moved NVML into `nvidia-driver-common`, so nixGL
-selects the right one automatically based on your detected driver branch. If a
-future branch reshuffles packaging again, the `mlPackage` selection in
-`nixGL.nix` is where to adjust it.
+NVIDIA occasionally reorganizes how the driver is split across RPMs. nixGL pulls the GL/EGL/GLX libraries from `nvidia-driver-libs` and the NVML library (`libnvidia-ml.so`, needed by tools like `btop`) from a second package. Up to the 595 branch that package is the standalone `libnvidia-ml`; starting with the 610 branch NVIDIA dropped it and moved NVML into `nvidia-driver-common`, so nixGL selects the right one automatically based on your detected driver branch. If a future branch reshuffles packaging again, the `mlPackage` selection in `nixGL.nix` is where to adjust it.
 
 ## Installation from source
 
 ```bash
-git clone https://github.com/nix-community/nixGL
-cd nixGL
-nix-env -f ./ -iA <your desired wrapper name>
+$ git clone https://github.com/nix-community/nixGL
+$ cd nixGL
+$ nix-env -f ./ -iA <your desired wrapper name>
 ```
 
 # Usage
@@ -187,17 +179,17 @@ Just launch the program you want prefixed by the right wrapper.
 For example, for OpenGL programs:
 
 ```bash
-nixGL program args                 # For the `nixGLDefault` wrapper, recommended.
-nixGLNvidia program args
-nixGLIntel program args
-nixGLNvidiaBumblebee program args
+$ nixGL program args                 # For the `nixGLDefault` wrapper, recommended.
+$ nixGLNvidia program args
+$ nixGLIntel program args
+$ nixGLNvidiaBumblebee program args
 ```
 
 For Vulkan programs:
 
 ```bash
-nixVulkanNvidia program args
-nixVulkanIntel program args
+$ nixVulkanNvidia program args
+$ nixVulkanIntel program args
 ```
 
 # OpenGL - Hybrid Intel + Nvidia laptop
@@ -214,7 +206,7 @@ OpenGL version string: 4.6.0 NVIDIA 390.25
 If the program you'd like to run is already installed by nix in your current environment, you can simply run it with the wrapper, for example:
 
 ```bash
-nixGLIntel blender
+$ nixGLIntel blender
 ```
 
 # Vulkan - Intel GPU
@@ -253,6 +245,7 @@ nix-build -A auto.nixGLNvidia --argstr nvidiaVersion 440.82
 ```
 
 (or `nixGLNvidiaBumblebee`, `nixVulkanNividia`)
+
 
 The version of your driver can be found using `glxinfo` from your system default package manager, or `nvidia-settings`.
 

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -15,11 +15,11 @@ driverSource ? "driver",
 # Enable 32 bits driver
 # This is one by default, you can switch it to off if you want to reduce a
 # bit the size of nixGL closure.
-enable32bits ? stdenv.hostPlatform.isx86
-, stdenv, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
-, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
-, mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
-, zlib, libdrm, xorg, wayland, gcc, zstd, rpm, cpio }:
+enable32bits ? stdenv.hostPlatform.isx86, stdenv, writeTextFile, shellcheck
+, pcre, runCommand, linuxPackages, fetchurl, lib, runtimeShell, bumblebee
+, libglvnd, vulkan-validation-layers, mesa, libvdpau-va-gl, intel-media-driver
+, pkgsi686Linux, driversi686Linux, zlib, libdrm, xorg, wayland, gcc, zstd, rpm
+, cpio }:
 
 let
   writeExecutable = { name, text }:
@@ -40,7 +40,8 @@ let
       '';
     };
 
-    writeNixGL = name: vadrivers: writeExecutable {
+  writeNixGL = name: vadrivers:
+    writeExecutable {
       inherit name;
       # add the 32 bits drivers if needed
       text = let
@@ -54,29 +55,46 @@ let
         '');
       in ''
         #!${runtimeShell}
-        export LIBGL_DRIVERS_PATH=${lib.makeSearchPathOutput "lib" "lib/dri" mesa-drivers}
-        export LIBVA_DRIVERS_PATH=${lib.makeSearchPathOutput "out" "lib/dri" (mesa-drivers ++ vadrivers)}
-        ${''export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json${
-          lib.optionalString enable32bits
-          ":${pkgsi686Linux.mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json"
-          }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''
+        export LIBGL_DRIVERS_PATH=${
+          lib.makeSearchPathOutput "lib" "lib/dri" mesa-drivers
         }
-        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau}:${glxindirect}/lib:${lib.makeLibraryPath [libglvnd]}"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        export LIBVA_DRIVERS_PATH=${
+          lib.makeSearchPathOutput "out" "lib/dri" (mesa-drivers ++ vadrivers)
+        }
+        ${''
+          export __EGL_VENDOR_LIBRARY_FILENAMES=${mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json${
+            lib.optionalString enable32bits
+            ":${pkgsi686Linux.mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json"
+          }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''}
+        export LD_LIBRARY_PATH=${lib.makeLibraryPath mesa-drivers}:${
+          lib.makeSearchPathOutput "lib" "lib/vdpau" libvdpau
+        }:${glxindirect}/lib:${
+          lib.makeLibraryPath [ libglvnd ]
+        }"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
         exec "$@"
       '';
     };
 
   top = rec {
-    /*
-    It contains the builder for different nvidia configuration, parametrized by
-    the version of the driver and sha256 sum of the driver installer file.
+    /* It contains the builder for different nvidia configuration, parametrized by
+       the version of the driver and sha256 sum of the driver installer file.
     */
     nvidiaPackages = { version, sha256 ? null }: rec {
 
       # download rpm packages if RHEL is selected as driver source
       rpmLibs = if driverSource == "rhel" then
         builtins.fetchurl {
-          url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-${version}-1.el9.x86_64.rpm";
+          url =
+            "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-${version}-1.el9.x86_64.rpm";
+        }
+      else
+        null;
+
+      # also get the ml library if RHEL is selected as driver source, required by btop and other tools
+      rpmMl = if driverSource == "rhel" then
+        builtins.fetchurl {
+          url =
+            "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/libnvidia-ml-${version}-1.el9.x86_64.rpm";
         }
       else
         null;
@@ -89,23 +107,27 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         nativeBuildInputs = [ rpm cpio ];
-        srcs = [ rpmLibs ];
+        srcs = [ rpmLibs rpmMl ];
         unpackPhase = ''
           mkdir -p $TMPDIR
           cp ${rpmLibs} $TMPDIR/nvidia-driver-libs.rpm
+          cp ${rpmMl} $TMPDIR/libnvidia-ml.rpm
         '';
         buildPhase = ''
-          mkdir -p $out
+          mkdir -p $out $out/lib $out/share
           cd $TMPDIR
 
           rpm2cpio nvidia-driver-libs.rpm | cpio -idmv
-          mv usr/lib64 $out/lib
-          mv usr/share $out/share
+          mv usr/lib64/* $out/lib
+          mv usr/share/* $out/share
+
+          rpm2cpio libnvidia-ml.rpm | cpio -idmv
+          mv usr/lib64/* $out/lib
         '';
       };
 
-      nvidiaDrivers = if driverSource == "driver" then (linuxPackages.nvidia_x11.override { }).overrideAttrs
-        (oldAttrs: rec {
+      nvidiaDrivers = if driverSource == "driver" then
+        (linuxPackages.nvidia_x11.override { }).overrideAttrs (oldAttrs: rec {
           pname = "nvidia";
           name = "nvidia-x11-${version}-nixGL";
           inherit version;
@@ -117,13 +139,16 @@ let
           else
             builtins.fetchurl url;
           useGLVND = true;
-          nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [zstd];
+          nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ zstd ];
         })
       else
         null;
 
       nvidiaLibsOnly = if driverSource == "driver" then
-        (nvidiaDrivers.override { libsOnly = true; kernel = null; })
+        (nvidiaDrivers.override {
+          libsOnly = true;
+          kernel = null;
+        })
       else
         nvidiaFromRpm;
 
@@ -158,20 +183,20 @@ let
             ${lib.optionalString (api == "Vulkan")
             "export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d"}
             NVIDIA_JSON=(${nvidiaLibsOnly}/share/glvnd/egl_vendor.d/*nvidia.json)
-            ${lib.optionalString enable32bits "NVIDIA_JSON32=(${nvidiaLibsOnly.lib32}/share/glvnd/egl_vendor.d/*nvidia.json)"}
+            ${lib.optionalString enable32bits
+            "NVIDIA_JSON32=(${nvidiaLibsOnly.lib32}/share/glvnd/egl_vendor.d/*nvidia.json)"}
 
-            ${''export __EGL_VENDOR_LIBRARY_FILENAMES=''${NVIDIA_JSON[*]}${
-              lib.optionalString enable32bits
-              '':''${NVIDIA_JSON32[*]}''
-              }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''
-            }
+            ${''
+              export __EGL_VENDOR_LIBRARY_FILENAMES=''${NVIDIA_JSON[*]}${
+                lib.optionalString enable32bits ":\${NVIDIA_JSON32[*]}"
+              }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''}
 
               ${
-                lib.optionalString (api == "Vulkan")
-                ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
-                  lib.optionalString enable32bits
-                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
-                }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
+                lib.optionalString (api == "Vulkan") ''
+                  export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
+                    lib.optionalString enable32bits
+                    ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
+                  }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
               }
               export LD_LIBRARY_PATH=${
                 lib.makeLibraryPath ([ libglvnd nvidiaLibsOnly ]
@@ -192,12 +217,10 @@ let
       nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
     };
 
+    nixGLMesa = writeNixGL "nixGLMesa" [ ];
 
-    nixGLMesa = writeNixGL "nixGLMesa" [  ];
-
-    nixGLIntel = writeNixGL "nixGLIntel"
-      ([ intel-media-driver ]
-       ++ lib.optionals enable32bits [ pkgsi686Linux.intel-media-driver ]);
+    nixGLIntel = writeNixGL "nixGLIntel" ([ intel-media-driver ]
+      ++ lib.optionals enable32bits [ pkgsi686Linux.intel-media-driver ]);
 
     nixVulkanMesa = writeExecutable {
       name = "nixVulkanIntel";
@@ -274,7 +297,7 @@ let
           versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
         in if versionMatch != null then builtins.head versionMatch else null;
 
-      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
+      autoNvidia = nvidiaPackages { version = nvidiaVersionAuto; };
     in rec {
       # The output derivation contains nixGL which point either to
       # nixGLNvidia or nixGLIntel using an heuristic.

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -74,13 +74,6 @@ let
     nvidiaPackages = { version, sha256 ? null }: rec {
 
       # download rpm packages if RHEL is selected as driver source
-      rpmDriver = if driverSource == "rhel" then
-        builtins.fetchurl {
-          url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-${version}-1.el9.x86_64.rpm";
-        }
-      else
-        null;
-
       rpmLibs = if driverSource == "rhel" then
         builtins.fetchurl {
           url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-${version}-1.el9.x86_64.rpm";
@@ -96,11 +89,10 @@ let
         preferLocalBuild = true;
         allowSubstitutes = false;
         nativeBuildInputs = [ rpm cpio ];
-        srcs = [ rpmDriver rpmLibs ];
+        srcs = [ rpmLibs ];
         unpackPhase = ''
           mkdir -p $TMPDIR
           cp ${rpmLibs} $TMPDIR/nvidia-driver-libs.rpm
-          cp ${rpmDriver} $TMPDIR/nvidia-driver.rpm
         '';
         buildPhase = ''
           mkdir -p $out
@@ -109,11 +101,6 @@ let
           rpm2cpio nvidia-driver-libs.rpm | cpio -idmv
           mv usr/lib64 $out/lib
           mv usr/share $out/share
-
-          rpm2cpio nvidia-driver.rpm | cpio -idmv
-          mv usr/bin $out/bin
-          mv usr/share $out/share
-          mv usr/lib $out/lib
         '';
       };
 

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -9,6 +9,9 @@ nvidiaHash ? null,
 # /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
 # https://github.com/NixOS/nix/issues/3539 ).
 nvidiaVersionFile ? null,
+# Nvidia driver source selection: "driver" (default) which will attempt to download .run file from NVIDIA's driver site
+# or "rhel", which downloads the RPM packages from NVIDIA's RHEL repository, ensuring a version match in RHEL systems like Rocky Linux, Fedora or CentOS.
+driverSource ? "driver",
 # Enable 32 bits driver
 # This is one by default, you can switch it to off if you want to reduce a
 # bit the size of nixGL closure.
@@ -16,7 +19,7 @@ enable32bits ? stdenv.hostPlatform.isx86
 , stdenv, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
 , fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
 , mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
-, zlib, libdrm, xorg, wayland, gcc, zstd }:
+, zlib, libdrm, xorg, wayland, gcc, zstd, rpm, cpio }:
 
 let
   writeExecutable = { name, text }:
@@ -62,13 +65,59 @@ let
         exec "$@"
       '';
     };
+
   top = rec {
     /*
     It contains the builder for different nvidia configuration, parametrized by
     the version of the driver and sha256 sum of the driver installer file.
     */
     nvidiaPackages = { version, sha256 ? null }: rec {
-      nvidiaDrivers = (linuxPackages.nvidia_x11.override { }).overrideAttrs
+
+      # download rpm packages if RHEL is selected as driver source
+      rpmDriver = if driverSource == "rhel" then
+        builtins.fetchurl {
+          url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-${version}-1.el9.x86_64.rpm";
+        }
+      else
+        null;
+
+      rpmLibs = if driverSource == "rhel" then
+        builtins.fetchurl {
+          url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-${version}-1.el9.x86_64.rpm";
+        }
+      else
+        null;
+
+      # Extract NVIDIA shared libraries from RPM
+      nvidiaFromRpm = stdenv.mkDerivation {
+        pname = "nvidia";
+        name = "nvidia-${version}-nixGL-rpm";
+        version = version;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        nativeBuildInputs = [ rpm cpio ];
+        srcs = [ rpmDriver rpmLibs ];
+        unpackPhase = ''
+          mkdir -p $TMPDIR
+          cp ${rpmLibs} $TMPDIR/nvidia-driver-libs.rpm
+          cp ${rpmDriver} $TMPDIR/nvidia-driver.rpm
+        '';
+        buildPhase = ''
+          mkdir -p $out
+          cd $TMPDIR
+
+          rpm2cpio nvidia-driver-libs.rpm | cpio -idmv
+          mv usr/lib64 $out/lib
+          mv usr/share $out/share
+
+          rpm2cpio nvidia-driver.rpm | cpio -idmv
+          mv usr/bin $out/bin
+          mv usr/share $out/share
+          mv usr/lib $out/lib
+        '';
+      };
+
+      nvidiaDrivers = if driverSource == "driver" then (linuxPackages.nvidia_x11.override { }).overrideAttrs
         (oldAttrs: rec {
           pname = "nvidia";
           name = "nvidia-x11-${version}-nixGL";
@@ -82,12 +131,14 @@ let
             builtins.fetchurl url;
           useGLVND = true;
           nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [zstd];
-        });
+        })
+      else
+        null;
 
-      nvidiaLibsOnly = nvidiaDrivers.override {
-        libsOnly = true;
-        kernel = null;
-      };
+      nvidiaLibsOnly = if driverSource == "driver" then
+        (nvidiaDrivers.override { libsOnly = true; kernel = null; })
+      else
+        nvidiaFromRpm;
 
       nixGLNvidiaBumblebee = writeExecutable {
         name = "nixGLNvidiaBumblebee-${version}";

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -9,18 +9,21 @@ nvidiaHash ? null,
 # /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
 # https://github.com/NixOS/nix/issues/3539 ).
 nvidiaVersionFile ? null,
-# Nvidia driver source selection: "driver" (default) or "rhel" (downloads RPMs from NVIDIA's RHEL repo)
+# Nvidia driver source selection: "driver" (default) downloads the .run file from
+# NVIDIA's driver site; "rhel" downloads the RPMs from NVIDIA's RHEL CUDA repo,
+# ensuring a version match on RHEL-based distros (Rocky, CentOS, Fedora).
 driverSource ? "driver",
-# RHEL major version (e.g., 9 or 10) for NVIDIA RPM URLs. User must set this if using driverSource = "rhel"
+# RHEL major version (e.g. 9 or 10) used to build the NVIDIA RPM URLs. Only used
+# when driverSource = "rhel"; set it to match your distribution.
 rhelMajorVersion ? 10,
 # Enable 32 bits driver
 # This is one by default, you can switch it to off if you want to reduce a
 # bit the size of nixGL closure.
-enable32bits ? stdenv.hostPlatform.isx86, stdenv, writeTextFile, shellcheck
-, pcre, runCommand, linuxPackages, fetchurl, lib, runtimeShell, bumblebee
-, libglvnd, vulkan-validation-layers, mesa, libvdpau-va-gl, intel-media-driver
-, pkgsi686Linux, driversi686Linux, zlib, libdrm, xorg, wayland, gcc, zstd, rpm
-, cpio }:
+enable32bits ? stdenv.hostPlatform.isx86
+, stdenv, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
+, fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
+, mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
+, zlib, libdrm, xorg, wayland, gcc, zstd, rpm, cpio }:
 
 let
   writeExecutable = { name, text }:
@@ -41,8 +44,7 @@ let
       '';
     };
 
-  writeNixGL = name: vadrivers:
-    writeExecutable {
+    writeNixGL = name: vadrivers: writeExecutable {
       inherit name;
       # add the 32 bits drivers if needed
       text = let
@@ -68,45 +70,42 @@ let
         exec "$@"
       '';
     };
-
   top = rec {
-    /* It contains the builder for different nvidia configuration, parametrized by
-       the version of the driver and sha256 sum of the driver installer file.
+    /*
+    It contains the builder for different nvidia configuration, parametrized by
+    the version of the driver and sha256 sum of the driver installer file.
     */
     nvidiaPackages = { version, sha256 ? null }: rec {
-
-      # Helper to build a URL for a package in NVIDIA's RHEL CUDA repo.
+      # Build a URL for a package in NVIDIA's RHEL CUDA repo.
       rpmUrl = pkg:
         "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/${pkg}-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
 
-      # NVIDIA reorganized the CUDA-repo driver packaging with the 610 branch:
-      # the standalone `libnvidia-ml` RPM (shipped for 580..595) was dropped, and
-      # libnvidia-ml.so moved into the new `nvidia-driver-common` package (which
-      # also carries libnvidia-cfg.so and libnvidia-gpucomp.so). Pick whichever
-      # package provides NVML for the detected driver branch.
+      # NVIDIA reorganized the CUDA-repo driver packaging with the 610 branch: the
+      # standalone `libnvidia-ml` RPM (shipped for 580..595) was dropped, and
+      # libnvidia-ml.so moved into the new `nvidia-driver-common` package. Pick
+      # whichever package provides NVML for the detected driver branch.
       driverBranch = lib.toInt (lib.versions.major version);
       mlPackage =
         if driverBranch >= 610 then "nvidia-driver-common" else "libnvidia-ml";
 
-      # download rpm packages if RHEL is selected as driver source
+      # Download the GL/EGL/GLX libraries when RHEL is the driver source.
       rpmLibs = if driverSource == "rhel" then
         builtins.fetchurl { url = rpmUrl "nvidia-driver-libs"; }
       else
         null;
 
-      # also get the NVML library (libnvidia-ml.so) if RHEL is selected as driver
-      # source, required by btop and other tools. Its providing package depends
-      # on the driver branch (see mlPackage above).
+      # Also download the NVML library (libnvidia-ml.so), required by tools like
+      # btop. Its providing package depends on the driver branch (see mlPackage).
       rpmMl = if driverSource == "rhel" then
         builtins.fetchurl { url = rpmUrl mlPackage; }
       else
         null;
 
-      # Extract NVIDIA shared libraries from RPM
+      # Extract the NVIDIA shared libraries from the RPMs.
       nvidiaFromRpm = stdenv.mkDerivation {
         pname = "nvidia";
         name = "nvidia-${version}-nixGL-rpm";
-        version = version;
+        inherit version;
         preferLocalBuild = true;
         allowSubstitutes = false;
         nativeBuildInputs = [ rpm cpio ];
@@ -134,7 +133,8 @@ let
       nvidiaDrivers = if driverSource == "rhel" then
         null
       else
-        (linuxPackages.nvidia_x11.override { }).overrideAttrs (oldAttrs: rec {
+        (linuxPackages.nvidia_x11.override { }).overrideAttrs
+        (oldAttrs: rec {
           pname = "nvidia";
           name = "nvidia-x11-${version}-nixGL";
           inherit version;
@@ -146,16 +146,16 @@ let
           else
             builtins.fetchurl url;
           useGLVND = true;
-          nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ zstd ];
+          nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [zstd];
         });
 
       nvidiaLibsOnly = if driverSource == "rhel" then
         nvidiaFromRpm
       else
-        (nvidiaDrivers.override {
+        nvidiaDrivers.override {
           libsOnly = true;
           kernel = null;
-        });
+        };
 
       nixGLNvidiaBumblebee = writeExecutable {
         name = "nixGLNvidiaBumblebee-${version}";
@@ -188,20 +188,20 @@ let
             ${lib.optionalString (api == "Vulkan")
             "export VK_LAYER_PATH=${vulkan-validation-layers}/share/vulkan/explicit_layer.d"}
             NVIDIA_JSON=(${nvidiaLibsOnly}/share/glvnd/egl_vendor.d/*nvidia.json)
-            ${lib.optionalString enable32bits
-            "NVIDIA_JSON32=(${nvidiaLibsOnly.lib32}/share/glvnd/egl_vendor.d/*nvidia.json)"}
+            ${lib.optionalString enable32bits "NVIDIA_JSON32=(${nvidiaLibsOnly.lib32}/share/glvnd/egl_vendor.d/*nvidia.json)"}
 
-            ${''
-              export __EGL_VENDOR_LIBRARY_FILENAMES=''${NVIDIA_JSON[*]}${
-                lib.optionalString enable32bits ":\${NVIDIA_JSON32[*]}"
-              }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''}
+            ${''export __EGL_VENDOR_LIBRARY_FILENAMES=''${NVIDIA_JSON[*]}${
+              lib.optionalString enable32bits
+              '':''${NVIDIA_JSON32[*]}''
+              }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''
+            }
 
               ${
-                lib.optionalString (api == "Vulkan") ''
-                  export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
-                    lib.optionalString enable32bits
-                    ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
-                  }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
+                lib.optionalString (api == "Vulkan")
+                ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
+                  lib.optionalString enable32bits
+                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
+                }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
               }
               export LD_LIBRARY_PATH=${
                 lib.makeLibraryPath ([ libglvnd nvidiaLibsOnly ]
@@ -222,10 +222,12 @@ let
       nixVulkanNvidia = nixNvidiaWrapper "Vulkan";
     };
 
-    nixGLMesa = writeNixGL "nixGLMesa" [ ];
 
-    nixGLIntel = writeNixGL "nixGLIntel" ([ intel-media-driver ]
-      ++ lib.optionals enable32bits [ pkgsi686Linux.intel-media-driver ]);
+    nixGLMesa = writeNixGL "nixGLMesa" [  ];
+
+    nixGLIntel = writeNixGL "nixGLIntel"
+      ([ intel-media-driver ]
+       ++ lib.optionals enable32bits [ pkgsi686Linux.intel-media-driver ]);
 
     nixVulkanMesa = writeExecutable {
       name = "nixVulkanIntel";
@@ -302,7 +304,7 @@ let
           versionMatch = builtins.match ".*Module  ([0-9.]+)  .*" data;
         in if versionMatch != null then builtins.head versionMatch else null;
 
-      autoNvidia = nvidiaPackages { version = nvidiaVersionAuto; };
+      autoNvidia = nvidiaPackages {version = nvidiaVersionAuto; };
     in rec {
       # The output derivation contains nixGL which point either to
       # nixGLNvidia or nixGLIntel using an heuristic.

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -12,8 +12,8 @@ nvidiaVersionFile ? null,
 # Nvidia driver source selection:
 #   "driver" (default) - download the .run installer from NVIDIA's XFree86 site.
 #   "rhel"             - extract the libraries from the RPMs in NVIDIA's RHEL CUDA repo.
-# Why "rhel" is needed: on RHEL-based distros (Rocky, RHEL, CentOS, Fedora) the
-# driver is installed from NVIDIA's RHEL repository, and many of those exact
+# Why "rhel" is needed: on RHEL-family distros (RHEL, Rocky, AlmaLinux, CentOS
+# Stream) the driver is installed from NVIDIA's RHEL repository, and many of those
 # versions are never published as a standalone .run installer on the XFree86
 # site. The two channels carry different sets of version numbers. Since nixGL
 # auto-detects the *installed* version, the default "driver" source frequently
@@ -31,6 +31,11 @@ enable32bits ? stdenv.hostPlatform.isx86
 , fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
 , mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
 , zlib, libdrm, xorg, wayland, gcc, zstd, rpm, cpio }:
+
+# The "rhel" source only ships 64-bit libraries (no lib32 output), so fail fast
+# with a clear message rather than a confusing missing-attribute error later.
+assert lib.assertMsg (!(driverSource == "rhel" && enable32bits))
+  ''nixGL: driverSource = "rhel" provides 64-bit libraries only; set enable32bits = false when using it.'';
 
 let
   writeExecutable = { name, text }:
@@ -115,6 +120,8 @@ let
         inherit version;
         preferLocalBuild = true;
         allowSubstitutes = false;
+        # $out is populated entirely in buildPhase; there is no Makefile to install.
+        dontInstall = true;
         nativeBuildInputs = [ rpm cpio ];
         srcs = [ rpmLibs rpmMl ];
         unpackPhase = ''
@@ -138,7 +145,10 @@ let
       };
 
       nvidiaDrivers = if driverSource == "rhel" then
-        null
+        # Evaluated lazily: only forced if a consumer that needs the full driver
+        # (e.g. the Bumblebee wrapper) is built. The RPM path provides libraries
+        # only, with no kernel-module driver, so those wrappers are unsupported.
+        throw ''nixGL: driverSource = "rhel" provides prebuilt libraries only and has no kernel-module driver, so nixGLNvidiaBumblebee is unavailable; use nixGLNvidia or nixVulkanNvidia instead.''
       else
         (linuxPackages.nvidia_x11.override { }).overrideAttrs
         (oldAttrs: rec {

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -9,9 +9,10 @@ nvidiaHash ? null,
 # /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
 # https://github.com/NixOS/nix/issues/3539 ).
 nvidiaVersionFile ? null,
-# Nvidia driver source selection: "driver" (default) which will attempt to download .run file from NVIDIA's driver site
-# or "rhel", which downloads the RPM packages from NVIDIA's RHEL repository, ensuring a version match in RHEL systems like Rocky Linux, Fedora or CentOS.
+# Nvidia driver source selection: "driver" (default) or "rhel" (downloads RPMs from NVIDIA's RHEL repo)
 driverSource ? "driver",
+# RHEL major version (e.g., 9 or 10) for NVIDIA RPM URLs. User must set this if using driverSource = "rhel"
+rhelMajorVersion ? 10,
 # Enable 32 bits driver
 # This is one by default, you can switch it to off if you want to reduce a
 # bit the size of nixGL closure.
@@ -85,7 +86,7 @@ let
       rpmLibs = if driverSource == "rhel" then
         builtins.fetchurl {
           url =
-            "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-${version}-1.el9.x86_64.rpm";
+            "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/nvidia-driver-libs-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
         }
       else
         null;
@@ -94,7 +95,7 @@ let
       rpmMl = if driverSource == "rhel" then
         builtins.fetchurl {
           url =
-            "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/libnvidia-ml-${version}-1.el9.x86_64.rpm";
+            "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/libnvidia-ml-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
         }
       else
         null;

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -82,21 +82,30 @@ let
     */
     nvidiaPackages = { version, sha256 ? null }: rec {
 
+      # Helper to build a URL for a package in NVIDIA's RHEL CUDA repo.
+      rpmUrl = pkg:
+        "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/${pkg}-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
+
+      # NVIDIA reorganized the CUDA-repo driver packaging with the 610 branch:
+      # the standalone `libnvidia-ml` RPM (shipped for 580..595) was dropped, and
+      # libnvidia-ml.so moved into the new `nvidia-driver-common` package (which
+      # also carries libnvidia-cfg.so and libnvidia-gpucomp.so). Pick whichever
+      # package provides NVML for the detected driver branch.
+      driverBranch = lib.toInt (lib.versions.major version);
+      mlPackage =
+        if driverBranch >= 610 then "nvidia-driver-common" else "libnvidia-ml";
+
       # download rpm packages if RHEL is selected as driver source
       rpmLibs = if driverSource == "rhel" then
-        builtins.fetchurl {
-          url =
-            "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/nvidia-driver-libs-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
-        }
+        builtins.fetchurl { url = rpmUrl "nvidia-driver-libs"; }
       else
         null;
 
-      # also get the ml library if RHEL is selected as driver source, required by btop and other tools
+      # also get the NVML library (libnvidia-ml.so) if RHEL is selected as driver
+      # source, required by btop and other tools. Its providing package depends
+      # on the driver branch (see mlPackage above).
       rpmMl = if driverSource == "rhel" then
-        builtins.fetchurl {
-          url =
-            "https://developer.download.nvidia.com/compute/cuda/repos/rhel${toString rhelMajorVersion}/x86_64/libnvidia-ml-${version}-1.el${toString rhelMajorVersion}.x86_64.rpm";
-        }
+        builtins.fetchurl { url = rpmUrl mlPackage; }
       else
         null;
 
@@ -112,7 +121,7 @@ let
         unpackPhase = ''
           mkdir -p $TMPDIR
           cp ${rpmLibs} $TMPDIR/nvidia-driver-libs.rpm
-          cp ${rpmMl} $TMPDIR/libnvidia-ml.rpm
+          cp ${rpmMl} $TMPDIR/nvidia-ml.rpm
         '';
         buildPhase = ''
           mkdir -p $out $out/lib $out/share
@@ -122,7 +131,9 @@ let
           mv usr/lib64/* $out/lib
           mv usr/share/* $out/share
 
-          rpm2cpio libnvidia-ml.rpm | cpio -idmv
+          # The NVML package (libnvidia-ml or nvidia-driver-common depending on
+          # the driver branch) only ships libraries under usr/lib64.
+          rpm2cpio nvidia-ml.rpm | cpio -idmv
           mv usr/lib64/* $out/lib
         '';
       };

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -9,9 +9,16 @@ nvidiaHash ? null,
 # /proc/driver/nvidia/version. Nix doesn't like zero-sized files (see
 # https://github.com/NixOS/nix/issues/3539 ).
 nvidiaVersionFile ? null,
-# Nvidia driver source selection: "driver" (default) downloads the .run file from
-# NVIDIA's driver site; "rhel" downloads the RPMs from NVIDIA's RHEL CUDA repo,
-# ensuring a version match on RHEL-based distros (Rocky, CentOS, Fedora).
+# Nvidia driver source selection:
+#   "driver" (default) - download the .run installer from NVIDIA's XFree86 site.
+#   "rhel"             - extract the libraries from the RPMs in NVIDIA's RHEL CUDA repo.
+# Why "rhel" is needed: on RHEL-based distros (Rocky, RHEL, CentOS, Fedora) the
+# driver is installed from NVIDIA's RHEL repository, and many of those exact
+# versions are never published as a standalone .run installer on the XFree86
+# site. The two channels carry different sets of version numbers. Since nixGL
+# auto-detects the *installed* version, the default "driver" source frequently
+# 404s for it. Pulling from the same RHEL repo that supplied the running driver
+# guarantees the exact version is available.
 driverSource ? "driver",
 # RHEL major version (e.g. 9 or 10) used to build the NVIDIA RPM URLs. Only used
 # when driverSource = "rhel"; set it to match your distribution.

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -126,7 +126,9 @@ let
         '';
       };
 
-      nvidiaDrivers = if driverSource == "driver" then
+      nvidiaDrivers = if driverSource == "rhel" then
+        null
+      else
         (linuxPackages.nvidia_x11.override { }).overrideAttrs (oldAttrs: rec {
           pname = "nvidia";
           name = "nvidia-x11-${version}-nixGL";
@@ -140,17 +142,15 @@ let
             builtins.fetchurl url;
           useGLVND = true;
           nativeBuildInputs = oldAttrs.nativeBuildInputs or [ ] ++ [ zstd ];
-        })
-      else
-        null;
+        });
 
-      nvidiaLibsOnly = if driverSource == "driver" then
+      nvidiaLibsOnly = if driverSource == "rhel" then
+        nvidiaFromRpm
+      else
         (nvidiaDrivers.override {
           libsOnly = true;
           kernel = null;
-        })
-      else
-        nvidiaFromRpm;
+        });
 
       nixGLNvidiaBumblebee = writeExecutable {
         name = "nixGLNvidiaBumblebee-${version}";


### PR DESCRIPTION
On certain distros, where the NVIDIA driver is typically installed via the NVIDIA driver repositories, trying to install the driver from the download site will commonly fail with a 404 error, like described in #170 and #124 and #67.

There have been approaches to solve this, e.g. in #184, but this will not work reliably. The key problem is that NVIDIA is not providing consistent versions of their drivers on different distribution channels. For Rocky Linux, and all other RHEL distros, the latest version on the download site differs. e.g. at the time of writing, the latest on downloads `.run` is 570.124.**04**, while the `.rpm` version in the RHEL repository is 570.124.**06**:

Driver download: https://download.nvidia.com/XFree86/Linux-x86_64/570.124.04/
RHEL repository: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-driver-libs-570.124.06-1.el9.x86_64.rpm

Using a different version, even if it's a small difference in the minor version, does not work in my experience. One could always manually install a driver, but in the case of RHEL it's way better to get the NVIDIA driver installed and updated via the default package manager and update cycle.

To solve this issue, I've created a [fork](https://github.com/Aietes/nixGL/tree/rhel) with an additional derivation in nixGL, that gets the driver from the RHEL repository from the `.rpm`. This works well for me, and should solve the issue for RHEL users. It it would be nice if it could be merged.

To get the driver from the RHEL `.rpm` instead of the driver download site, simply set `driverSource` to `rhel`. Also ensure that `enable32bits` is changed from its default to `false`, as at this point I did not include the 32bit version of the driver. Here's an example from my `.nix` using `home-manager`:

```nix
{
  nixpkgs = {
    overlays = specialArgs.overlays;
    config = { allowUnfree = true; };
  };

  home.packages = with pkgs; [
    (nixgl.override {
      driverSource = "rhel";
      enable32bits = false;
    }).auto.nixGLDefault
    (config.lib.nixGL.wrap ghostty)
  ];

  nixGL = {
   packages = pkgs.nixgl.override {
    driverSource = "rhel";
    enable32bits = false;
   };
   defaultWrapper = "nvidia";
  };
```

If you face the driver problem and you are on any RHEL distro like Rocky, Fedora, etc., you can use the nixGL overlay from my fork until this is merged:

```nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    nixgl = {
      url = "github:Aietes/nixGL/rhel";
    };
  };
  ....
```

Something similar can probably be done for Debian and other distros, using the official NVIDIA driver for a specific distro as the source for nixGL.

Fixes #170 #124 #67