### PR TITLE
Add GBM_BACKENDS_PATH to nixNvidiaWrapper

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -128,6 +128,7 @@ let
               '':''${NVIDIA_JSON32[*]}''
               }"''${__EGL_VENDOR_LIBRARY_FILENAMES:+:$__EGL_VENDOR_LIBRARY_FILENAMES}"''
             }
+            export GBM_BACKENDS_PATH=${lib.makeSearchPathOutput "lib" "lib/gbm" [ nvidiaLibsOnly ]}
 
               ${
                 lib.optionalString (api == "Vulkan")


### PR DESCRIPTION
On Arch Linux, I found that `GBM_BACKENDS_PATH` is necessary for `pkgs.hyprland` to work.

<details>
<summary>My setup</summary>

```ShellSession
$ nix-shell -p nix-info --run "nix-info -m"
this path will be fetched (0.00 MiB download, 0.00 MiB unpacked):
  /nix/store/2h8fjpm8vnbqg1s3gvsz3yx3xljkj365-nix-info
copying path '/nix/store/2h8fjpm8vnbqg1s3gvsz3yx3xljkj365-nix-info' from 'https://cache.nixos.org'...
 - system: `"x86_64-linux"`
 - host os: `Linux 6.16.8-arch3-1, Arch Linux, noversion, rolling`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.31.2`
 - nixpkgs: `/nix/store/01yzp96024m0hnj71sdnd58ic23sqcp9-nixpkgs/nixpkgs`

$ cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  580.82.09  Release Build  (root@geo)  
GCC version:  gcc version 14.3.0 (GCC) 

$ cat ~/.nix-profile/bin/Hyprland 
#! /nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash -e
exec -a "Hyprland" "/nix/store/a44y1bvaz1rbf69xblrz9xfhzjzdmxzq-nixGLCombinedWrapper-Nvidia/bin/nixGLCombinedWrapper-Nvidia"  /nix/store/hdp9gx85n28vdbz2qim6lrp0sdr2djll-hyprland-0.51.0/bin/Hyprland "$@" 

$ cat /nix/store/a44y1bvaz1rbf69xblrz9xfhzjzdmxzq-nixGLCombinedWrapper-Nvidia/bin/nixGLCombinedWrapper-Nvidia
#!/nix/store/q7sqwn7i6w2b67adw0bmix29pxg85x3w-bash-5.3p3/bin/bash
exec /nix/store/r5721j173wdjfmkgr08bs8hfv3zdrrif-nixGLNvidia-580.82.09/bin/nixGLNvidia-580.82.09  "$@"
```

aside: in order to get things actually working, I also needed to merge https://github.com/nix-community/nixGL/pull/187

</details>