### PR TITLE
Use stdenv.hostPlatform.system instead of deprecated system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
         # deprecated attributes for retro compatibility
         overlay = overlays.default;
         overlays.default = final: _:
-          let isIntelX86Platform = final.system == "x86_64-linux";
+          let isIntelX86Platform = final.stdenv.hostPlatform.system == "x86_64-linux";
           in {
             nixgl = import ./default.nix {
               pkgs = final;


### PR DESCRIPTION
Resolves error "evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'"

Tested by pointing my nixgl input at `github:kberanek/nixGL` instead of `github:nix-community/nixGL` and verified the warning is gone and everything seems to work as expected after deploying to a test host.